### PR TITLE
Gave sheep armor for their wool.

### DIFF
--- a/src/main/java/vazkii/quark/tweaks/QuarkTweaks.java
+++ b/src/main/java/vazkii/quark/tweaks/QuarkTweaks.java
@@ -29,6 +29,7 @@ import vazkii.quark.tweaks.feature.NoPotionShift;
 import vazkii.quark.tweaks.feature.NoteBlocksMobSounds;
 import vazkii.quark.tweaks.feature.RightClickSignEdit;
 import vazkii.quark.tweaks.feature.ShearableChickens;
+import vazkii.quark.tweaks.feature.SheepArmor;
 import vazkii.quark.tweaks.feature.SlabsToBlocks;
 import vazkii.quark.tweaks.feature.SnowGolemPlayerHeads;
 import vazkii.quark.tweaks.feature.StackableItems;
@@ -60,6 +61,7 @@ public class QuarkTweaks extends Module {
 		registerFeature(new ShearableChickens());
 		registerFeature(new MinecartInteraction(), "Right click minecarts to add blocks to them");
 		registerFeature(new EndermenTeleportYou(), "Endermen teleport you to them if you're in a 2 high area");
+		registerFeature(new SheepArmor(), "Sheep have armor while wearing wool");
 	}
 
 }

--- a/src/main/java/vazkii/quark/tweaks/feature/SheepArmor.java
+++ b/src/main/java/vazkii/quark/tweaks/feature/SheepArmor.java
@@ -1,0 +1,53 @@
+/**
+ * This class was created by <Darkhax>. It's distributed as
+ * part of the Quark Mod. Get the Source Code in github:
+ * https://github.com/Vazkii/Quark
+ * 
+ * Quark is Open Source and distributed under the
+ * [ADD-LICENSE-HERE]
+ * 
+ * File Created @ [06/06/2016, 17:06:43 (GMT)]
+ */
+package vazkii.quark.tweaks.feature;
+
+import java.util.UUID;
+
+import net.minecraft.entity.SharedMonsterAttributes;
+import net.minecraft.entity.ai.attributes.AttributeModifier;
+import net.minecraft.entity.ai.attributes.ModifiableAttributeInstance;
+import net.minecraft.entity.passive.EntitySheep;
+import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import vazkii.quark.base.module.Feature;
+
+public class SheepArmor extends Feature {
+
+	public static AttributeModifier sheepArmor = new AttributeModifier(UUID.fromString("6e915cea-3f18-485d-a818-373fe4f75f7f"), "sheep_armor", 1.0d, 0);
+	
+	@Override
+	public void setupConfig() {
+		double armorAmount = loadPropDouble("Sheep Armor Amount", "The amount of armor points to give to a sheep when it is not sheared.", 1.0d);
+		sheepArmor = new AttributeModifier(UUID.fromString("6e915cea-3f18-485d-a818-373fe4f75f7f"), "sheep_armor", armorAmount, 0);
+	}
+	
+	@SubscribeEvent
+	public void onUpdate(LivingUpdateEvent event) {
+		if(event.getEntityLiving() instanceof EntitySheep) {
+			EntitySheep entity = (EntitySheep) event.getEntityLiving();
+			ModifiableAttributeInstance armorAttribute = (ModifiableAttributeInstance) entity.getEntityAttribute(SharedMonsterAttributes.ARMOR);
+			boolean hasModifier = armorAttribute.hasModifier(sheepArmor);
+			boolean isSheared = entity.getSheared();
+			
+			if (!isSheared && !hasModifier)
+				armorAttribute.applyModifier(sheepArmor);
+			
+			else if (isSheared && hasModifier)
+				armorAttribute.removeModifier(sheepArmor);
+		}
+	}
+	
+	@Override
+	public boolean hasSubscriptions() {
+		return true;
+	}
+}


### PR DESCRIPTION
Hey, not sure if you are open to feature PRs but after showing this feature off I received a bunch of requests to PR it into Quark. The feature is actually really basic, when a sheep has wool it has one point of armor, and if it has been sheared it doesn't. This may seem like a trivial addition however I feel it does a great deal to flesh out sheep. It also means that sheep wont take as much damage from wolves or stray arrows / creeper blasts. 

This works by adding a +1 armor attribute to sheep when they have wool, and removing it when they have been sheared. This is handled in a similar way by vanilla potions. The UUID is a V4 ID generated by [this](https://www.uuidgenerator.net/) site. 

I tested and confirmed that this feature is working by using the armor point module in WAWLA. 
![animation](https://cloud.githubusercontent.com/assets/2250798/15857976/787a1e50-2c7b-11e6-8237-d26954d1d903.gif)
