### PR TITLE
Update ForgeGradle and set coreMod in build.gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,3 @@
 Small things.
 
 This mod makes use of the [Java Universal Tween Engine](https://code.google.com/p/java-universal-tween-engine/) by Aurelien Ribon, licensed under the Apache 2.0 License.  
-
-To run in a dev env, add *-Dfml.coreMods.load=vazkii.quark.base.asm.LoadingPlugin* to your VM arguments.

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:2.1-SNAPSHOT'
+        classpath 'net.minecraftforge.gradle:ForgeGradle:2.2-SNAPSHOT'
     }
 }
 
@@ -31,6 +31,8 @@ archivesBaseName = config.mod_name
 minecraft {
     version = "${config.mc_version}-${config.forge_version}-${config.mc_version}"
     runDir = "eclipse/assets"
+
+    coreMod = "vazkii.quark.base.asm.LoadingPlugin"
 
     mappings = config.mc_mappings
     replace 'GRADLE:BUILD', config.build_number


### PR DESCRIPTION
Forge 1.9.4 requires ForgeGradle 2.2, and will crash when decompiling MC without it, like when running `setupDecompWorkspace` for the first time.