### PR TITLE
Make BlockMetaVariants compile on Eclipse

### DIFF
--- a/src/main/java/vazkii/quark/base/block/BlockMetaVariants.java
+++ b/src/main/java/vazkii/quark/base/block/BlockMetaVariants.java
@@ -45,7 +45,7 @@ public class BlockMetaVariants<T extends Enum<T> & IStringSerializable> extends 
 
 	@Override
 	public int getMetaFromState(IBlockState state) {
-		return state.getValue(variantProp == null ? temporaryVariantProp : variantProp).ordinal();
+		return state.<T>getValue(variantProp == null ? temporaryVariantProp : variantProp).ordinal();
 	}
 
 	@Override


### PR DESCRIPTION
Explicitly give type parameter to `IBlockState.getValue()` in
`getMetaFromState()`.

This file used to compile fine under Oracle `javac`, but Eclipse's internal compiler infers the type to be `Comparable` and not `Enum`, then throws a fit because `ordinal()` is not defined on `Comparable`. Actually not sure if this is Oracle's `javac` doing some arcane magicks that aren't in the JLS or just Eclipse being dumb (related to Bug 441905?).

Same thing happens in Psi, too.