### PR TITLE
Made DeleteItems work on Macs

### DIFF
--- a/src/main/java/vazkii/quark/management/feature/DeleteItems.java
+++ b/src/main/java/vazkii/quark/management/feature/DeleteItems.java
@@ -22,7 +22,7 @@ public class DeleteItems extends Feature {
 	
 	@SubscribeEvent
 	public void keyboardEvent(GuiScreenEvent.KeyboardInputEvent.Post event) {
-		boolean down = Keyboard.isKeyDown(Keyboard.KEY_DELETE);
+		boolean down = Keyboard.isKeyDown(Keyboard.KEY_DELETE) || (Minecraft.IS_RUNNING_ON_MAC && Keyboard.isKeyDown(Keyboard.KEY_BACK));
 		if(GuiScreen.isCtrlKeyDown() && down && !this.down && event.getGui() instanceof GuiContainer) {
 			GuiContainer gui = (GuiContainer) event.getGui();
 			Slot slot = gui.getSlotUnderMouse();


### PR DESCRIPTION
Due to macs not having a delete key, they need to have a exception to the down variable.