### PR TITLE
Added more incompatible mods with the InventorySorter.

### DIFF
--- a/src/main/java/vazkii/quark/management/feature/InventorySorting.java
+++ b/src/main/java/vazkii/quark/management/feature/InventorySorting.java
@@ -69,7 +69,7 @@ public class InventorySorting extends Feature {
 	
 	@Override
 	public String[] getIncompatibleMods() {
-		return new String[] { "inventorytweaks", "inventorysorter" };
+		return new String[] { "inventorytweaks", "inventorysorter", "itemscroller", "mousetweaks" };
 	}
 
 	


### PR DESCRIPTION
- Added the modid for Item Scroller and Mouse Tweaks to the incompatible
mods string.
- Should fix #237.