### PR TITLE
Create and register serialisers for Quark's LootFunctions

### DIFF
--- a/src/main/java/vazkii/quark/world/feature/AncientTomes.java
+++ b/src/main/java/vazkii/quark/world/feature/AncientTomes.java
@@ -15,6 +15,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
+import com.google.gson.*;
+
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentData;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -29,11 +31,13 @@ import net.minecraft.world.storage.loot.LootEntryItem;
 import net.minecraft.world.storage.loot.LootTableList;
 import net.minecraft.world.storage.loot.conditions.LootCondition;
 import net.minecraft.world.storage.loot.functions.LootFunction;
+import net.minecraft.world.storage.loot.functions.LootFunctionManager;
 import net.minecraftforge.event.AnvilUpdateEvent;
 import net.minecraftforge.event.LootTableLoadEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import vazkii.quark.base.lib.LibMisc;
 import vazkii.quark.base.module.Feature;
 import vazkii.quark.world.item.ItemAncientTome;
 
@@ -51,6 +55,7 @@ public class AncientTomes extends Feature {
 		dungeonWeight = loadPropInt("Dungeon loot weight", "", 8);
 		libraryWeight = loadPropInt("Stronghold Library loot weight", "", 12);
 		itemQuality = loadPropInt("Item quality for loot", "", 2);
+		LootFunctionManager.registerFunction(new EnchantTomeFunction.Serializer());
 	}
 
 	@Override
@@ -181,7 +186,23 @@ public class AncientTomes extends Feature {
 			stack.addEnchantment(enchantment, enchantment.getMaxLevel());
 			return stack;
 		}
+		
+		public static class Serializer extends LootFunction.Serializer<EnchantTomeFunction> {
 
+			protected Serializer() {
+				super(new ResourceLocation(LibMisc.MOD_ID, "enchant_tome"), EnchantTomeFunction.class);
+			}
+
+			@Override
+			public void serialize(JsonObject object, EnchantTomeFunction functionClazz,
+					JsonSerializationContext serializationContext) {}
+
+			@Override
+			public EnchantTomeFunction deserialize(JsonObject object, JsonDeserializationContext deserializationContext,
+					LootCondition[] conditionsIn) {
+				return new EnchantTomeFunction();
+			}	
+		}
 	}
 
 }

--- a/src/main/java/vazkii/quark/world/feature/BuriedTreasure.java
+++ b/src/main/java/vazkii/quark/world/feature/BuriedTreasure.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Random;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.gson.*;
 
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
@@ -32,10 +33,12 @@ import net.minecraft.world.storage.loot.LootEntryItem;
 import net.minecraft.world.storage.loot.LootTableList;
 import net.minecraft.world.storage.loot.conditions.LootCondition;
 import net.minecraft.world.storage.loot.functions.LootFunction;
+import net.minecraft.world.storage.loot.functions.LootFunctionManager;
 import net.minecraftforge.event.LootTableLoadEvent;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import vazkii.arl.util.ItemNBTHelper;
+import vazkii.quark.base.lib.LibMisc;
 import vazkii.quark.base.module.Feature;
 
 public class BuriedTreasure extends Feature {
@@ -54,6 +57,7 @@ public class BuriedTreasure extends Feature {
 	public void setupConfig() {
 		rarity = loadPropInt("Treasure map Rarity", "", 10);
 		quality = loadPropInt("Treasure map item quality", "This is used for the luck attribute in loot tables. It doesn't affect the loot you get from the map itself.", 2);
+		LootFunctionManager.registerFunction(new SetAsTreasureFunction.Serializer());
 	}
 
 	@SubscribeEvent
@@ -174,6 +178,22 @@ public class BuriedTreasure extends Feature {
 			return stack;
 		}
 
+		public static class Serializer extends LootFunction.Serializer<SetAsTreasureFunction> {
+
+			protected Serializer() {
+				super(new ResourceLocation(LibMisc.MOD_ID, "set_treasure"),SetAsTreasureFunction.class);
+			}
+
+			@Override
+			public void serialize(JsonObject object, SetAsTreasureFunction functionClazz,
+					JsonSerializationContext serializationContext) {}
+
+			@Override
+			public SetAsTreasureFunction deserialize(JsonObject object, JsonDeserializationContext deserializationContext,
+					LootCondition[] conditionsIn) {
+				return new SetAsTreasureFunction();
+			}
+		}
 	}
 
 }


### PR DESCRIPTION
**What does this PR do?**
This PR allows Quark's LootFunctions to be serialised and deserialised.

**Why is this PR necessary?**
I make the mod [LootTweaker](https://github.com/Leviathan143/LootTweaker). LootTweaker has a command that dumps loot tables to files by serialising them. One of my users reported that having Quark installed caused a non-fatal error when this command was used. This error is caused by Quark's LootFunctions being unserialisable. While vanilla does not serialise loot tables as far as I am aware, other mods(like LootTweaker) may wish to. Additionally vanilla is capable of serialising loot tables, so I suspect it may do so in a future update.

This PR will also allow Quark's LootFunctions to be used in loot tables by users, as it makes the LootFunctions deserialisable. This would be necessary if a user wished to add an Ancient Tome or Treasure Map to a loot table.

I have tested this PR and it does not break Ancient Tomes or Treasure Maps.