### PR TITLE
Fix crash on invalid enchanted book

### DIFF
--- a/src/main/java/vazkii/quark/misc/feature/AncientTomes.java
+++ b/src/main/java/vazkii/quark/misc/feature/AncientTomes.java
@@ -107,6 +107,9 @@ public class AncientTomes extends Feature {
 				Map<Enchantment, Integer> enchants = EnchantmentHelper.getEnchantments(right);
 				if(enchants.size() == 1) {
 					Enchantment ench = enchants.keySet().iterator().next();
+					if(ench == null)
+						return;
+
 					int level = enchants.get(ench);
 
 					if(level > ench.getMaxLevel() && ench.canApply(left)) {


### PR DESCRIPTION
#347 was caused by a enchanted book whose enchantments, when gotten using the EnchantmentHelper, had a null somewhere. It appears to happen when there is an enchantment on the book that is not in the enchantment registry.