### PR TITLE
Update link to the Java UTE to Github

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ Small things.
 
 This mod requires [AutoRegLib](https://github.com/Vazkii/AutoRegLib).
 
-This mod makes use of the [Java Universal Tween Engine](https://code.google.com/p/java-universal-tween-engine/) by Aurelien Ribon, licensed under the Apache 2.0 License.  
+This mod makes use of the [Java Universal Tween Engine](https://github.com/AurelienRibon/universal-tween-engine) by Aurelien Ribon, licensed under the Apache 2.0 License.  


### PR DESCRIPTION
There is now an official Github repo for the Java Universal Tween Engine.