### PR TITLE
Check to make sure Enderman can pick-up the block. Fixes #466

### DIFF
--- a/src/main/java/vazkii/quark/tweaks/feature/EndermenAntiCheese.java
+++ b/src/main/java/vazkii/quark/tweaks/feature/EndermenAntiCheese.java
@@ -94,7 +94,7 @@ public class EndermenAntiCheese extends Feature {
 		
 		IBlockState state = entity.world.getBlockState(pos);
 		boolean unbreakable = state.getBlock().getBlockHardness(state, entity.world, pos) == -1 || !state.getBlock().canEntityDestroy(state, entity.world, pos, entity);
-		if(!unbreakable && state.getBlock().getCollisionBoundingBox(state, entity.getEntityWorld(), pos) != null) {
+		if(!unbreakable && state.getBlock().getCollisionBoundingBox(state, entity.getEntityWorld(), pos) != null && EntityEnderman.getCarriable(state.getBlock())) {
 			IBlockState carried = entity.getHeldBlockState();
 			if(carried != null) {
 				Block outBlock = carried.getBlock();


### PR DESCRIPTION
- Stops Enderman from being able to pick-up blocks that they're not supposed to.
- Fixes #466.