### PR TITLE
Blacklist moving integrateddynamics:cable with pistons

### DIFF
--- a/src/main/java/vazkii/quark/automation/feature/PistonsMoveTEs.java
+++ b/src/main/java/vazkii/quark/automation/feature/PistonsMoveTEs.java
@@ -36,7 +36,7 @@ public class PistonsMoveTEs extends Feature {
 		String[] renderBlacklistArray = loadPropStringList("Tile Entity Render Blacklist", "Some mod blocks with complex renders will break everything if moved. Add them here if you find any.", 
 				new String[] { "psi:programmer", "botania:starfield" });
 		String[] movementBlacklistArray = loadPropStringList("Tile Entity Movement Blacklist", "Blocks with Tile Entities that pistons should not be able to move.", 
-				new String[] { "minecraft:mob_spawner" });
+				new String[] { "minecraft:mob_spawner", "integrateddynamics:cable" });
 		String[] delayedUpdateListArray = loadPropStringList("Delayed Update List", "List of blocks whose tile entity update should be delayed by one tick after placed to prevent corruption.", 
 				new String[] { "minecraft:dispenser", "minecraft:dropper" });
 		


### PR DESCRIPTION
Integrated Dynamics doesn't support moving cables and will crash if you try (CyclopsMC/IntegratedDynamics#309), so we shouldn't allow it.