### PR TITLE
fix ancient tomes when using enchanted books with more than one enchantment

### DIFF
--- a/src/main/java/vazkii/quark/misc/feature/AncientTomes.java
+++ b/src/main/java/vazkii/quark/misc/feature/AncientTomes.java
@@ -139,16 +139,21 @@ public class AncientTomes extends Feature {
 	}
 
 	private void handleTome(ItemStack book, ItemStack tome, AnvilUpdateEvent event) {
-		Map<Enchantment, Integer> enchantsLeft = EnchantmentHelper.getEnchantments(book);
-		Map<Enchantment, Integer> enchantsRight = EnchantmentHelper.getEnchantments(tome);
-		
-		if(enchantsLeft.equals(enchantsRight)) {
-			Enchantment ench = enchantsRight.keySet().iterator().next();
-			ItemStack output = ProxyRegistry.newStack(Items.ENCHANTED_BOOK);
-			((ItemEnchantedBook) output.getItem()).addEnchantment(output, new EnchantmentData(ench, enchantsRight.get(ench) + 1));
-			event.setOutput(output);
-			event.setCost(mergeTomeCost);
+		Map<Enchantment, Integer> enchantsBook = EnchantmentHelper.getEnchantments(book);
+		Map<Enchantment, Integer> enchantsTome = EnchantmentHelper.getEnchantments(tome);
+		for (Map.Entry<Enchantment, Integer> entry : enchantsTome.entrySet()) {
+			if(enchantsBook.getOrDefault(entry.getKey(), 0).equals(entry.getValue())){
+				enchantsBook.put(entry.getKey(), entry.getValue() + 1);
+			} else {
+				return;
+			}
 		}
+		ItemStack output = ProxyRegistry.newStack(Items.ENCHANTED_BOOK);
+		for (Map.Entry<Enchantment, Integer> entry : enchantsBook.entrySet()) {
+			ItemEnchantedBook.addEnchantment(output, new EnchantmentData(entry.getKey(), entry.getValue()));
+		}
+		event.setOutput(output);
+		event.setCost(mergeTomeCost);
 	}
 
 	private String[] generateDefaultEnchantmentList() {


### PR DESCRIPTION
Fixes misbehaviour of ancient tomes when the target book has more than one enchantment, see screenshots.

Also handles tomes with multiple enchantments gracefully (those can be obtained using commands).

---

Before: ![2017-10-19_22 43 27](https://user-images.githubusercontent.com/10252708/31793257-0a18bf6a-b51f-11e7-8ccb-ac5784371e20.png)
After: ![2017-10-19_22 42 00](https://user-images.githubusercontent.com/10252708/31793282-1a03d7c0-b51f-11e7-84e2-3edd793eb6e4.png)

---

Before:![2017-10-19_22 43 34](https://user-images.githubusercontent.com/10252708/31793295-2124fd22-b51f-11e7-87de-6a456b5a1988.png)
After: ![2017-10-19_22 41 52](https://user-images.githubusercontent.com/10252708/31793297-25745706-b51f-11e7-8ea4-0c69b57c496d.png)

(always used the same books: tome with sharpness 5, and enchanted book with Sharpness 5 and Protection 1)



