### PR TITLE
fix ancient tomes when using enchanted books with more than one enchantment [follow up]

### DIFF
--- a/src/main/java/vazkii/quark/misc/feature/AncientTomes.java
+++ b/src/main/java/vazkii/quark/misc/feature/AncientTomes.java
@@ -139,16 +139,21 @@ public class AncientTomes extends Feature {
 	}
 
 	private void handleTome(ItemStack book, ItemStack tome, AnvilUpdateEvent event) {
-		Map<Enchantment, Integer> enchantsLeft = EnchantmentHelper.getEnchantments(book);
-		Map<Enchantment, Integer> enchantsRight = EnchantmentHelper.getEnchantments(tome);
-		
-		if(enchantsLeft.equals(enchantsRight)) {
-			Enchantment ench = enchantsRight.keySet().iterator().next();
-			ItemStack output = ProxyRegistry.newStack(Items.ENCHANTED_BOOK);
-			((ItemEnchantedBook) output.getItem()).addEnchantment(output, new EnchantmentData(ench, enchantsRight.get(ench) + 1));
-			event.setOutput(output);
-			event.setCost(mergeTomeCost);
+		Map<Enchantment, Integer> enchantsBook = EnchantmentHelper.getEnchantments(book);
+		Map<Enchantment, Integer> enchantsTome = EnchantmentHelper.getEnchantments(tome);
+		for (Map.Entry<Enchantment, Integer> entry : enchantsTome.entrySet()) {
+			if(enchantsBook.getOrDefault(entry.getKey(), 0).equals(entry.getValue())){
+				enchantsBook.put(entry.getKey(), entry.getValue() + 1);
+			} else {
+				return;
+			}
 		}
+		ItemStack output = ProxyRegistry.newStack(Items.ENCHANTED_BOOK);
+		for (Map.Entry<Enchantment, Integer> entry : enchantsBook.entrySet()) {
+			ItemEnchantedBook.addEnchantment(output, new EnchantmentData(entry.getKey(), entry.getValue()));
+		}
+		event.setOutput(output);
+		event.setCost(mergeTomeCost);
 	}
 
 	private String[] generateDefaultEnchantmentList() {

--- a/src/main/java/vazkii/quark/misc/feature/AncientTomes.java
+++ b/src/main/java/vazkii/quark/misc/feature/AncientTomes.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Iterator;
 
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonObject;
@@ -106,32 +107,53 @@ public class AncientTomes extends Feature {
 
 			else if(right.getItem() == Items.ENCHANTED_BOOK) {
 				Map<Enchantment, Integer> enchants = EnchantmentHelper.getEnchantments(right);
-				if(enchants.size() == 1) {
-					Enchantment ench = enchants.keySet().iterator().next();
-					if(ench == null)
-						return;
+				Map<Enchantment, Integer> currentEnchants = EnchantmentHelper.getEnchantments(left);
+				boolean hasOverLevel = false;
+				boolean hasMatching = false;
+				for (Map.Entry<Enchantment, Integer> entry : enchants.entrySet()) {
+					Enchantment ench = entry.getKey();
+					int level = entry.getValue();
+					if (level > ench.getMaxLevel()) {
+						hasOverLevel = true;
+						if (ench.canApply(left)) {
+							hasMatching = true;
+							//remove incompatible enchantments
+							for (Iterator<Enchantment> iterator = currentEnchants.keySet().iterator(); iterator.hasNext(); ) {
+								Enchantment enchCompare = iterator.next();
+								if (enchCompare == ench)
+									continue;
 
-					int level = enchants.get(ench);
-
-					if(level > ench.getMaxLevel() && ench.canApply(left)) {
-						ItemStack out = left.copy();
-
-						Map<Enchantment, Integer> currentEnchants = EnchantmentHelper.getEnchantments(out);
-						for(Enchantment enchCompare : currentEnchants.keySet()) {
-							if(enchCompare == ench)
+								if (!enchCompare.isCompatibleWith(ench)) {
+									iterator.remove();
+								}
+							}
+							currentEnchants.put(ench, level);
+						}
+					} else if (ench.canApply(left)) {
+						boolean compatible = true;
+						//don't apply incompatible enchantments
+						for (Enchantment enchCompare : currentEnchants.keySet()) {
+							if (enchCompare == ench)
 								continue;
-							
-							if(!enchCompare.isCompatibleWith(ench)) {
-								event.setCanceled(true);
-								return;
+
+							if (!enchCompare.isCompatibleWith(ench)) {
+								compatible = false;
+								break;
 							}
 						}
-						
-						currentEnchants.put(ench, level);
+						if (compatible) {
+							currentEnchants.put(ench, level);
+						}
+					}
+				}
+				if (hasOverLevel) {
+					if (hasMatching) {
+						ItemStack out = left.copy();
 						EnchantmentHelper.setEnchantments(currentEnchants, out);
-
 						event.setOutput(out);
 						event.setCost(applyTomeCost);
+					} else {
+						event.setCanceled(true);
 					}
 				}
 			}

--- a/src/main/java/vazkii/quark/misc/feature/AncientTomes.java
+++ b/src/main/java/vazkii/quark/misc/feature/AncientTomes.java
@@ -150,8 +150,14 @@ public class AncientTomes extends Feature {
 					if (hasMatching) {
 						ItemStack out = left.copy();
 						EnchantmentHelper.setEnchantments(currentEnchants, out);
+						String name = event.getName();
+						int cost = applyTomeCost;
+						if(name != null && !name.isEmpty()){
+							out.setStackDisplayName(name);
+							cost++;
+						}
 						event.setOutput(out);
-						event.setCost(applyTomeCost);
+						event.setCost(cost);
 					} else {
 						event.setCanceled(true);
 					}


### PR DESCRIPTION
Follow up to #652 
Fixes the cost to apply a book with overlevel enchantments when it has other enchantments.
Also allows renaming an item while applying such a book