### PR TITLE
Fix incorrect step assist height

### DIFF
--- a/src/main/java/vazkii/quark/tweaks/feature/JumpBoostStepAssist.java
+++ b/src/main/java/vazkii/quark/tweaks/feature/JumpBoostStepAssist.java
@@ -46,14 +46,14 @@ public class JumpBoostStepAssist extends Feature {
 				if(shouldPlayerHaveStepup(player)) {
 					if(canToggleWithSneak && player.isSneaking())
 						player.stepHeight = 0.50001F; // Not 0.5F because that is the default
-					else player.stepHeight = 1F;
+					else player.stepHeight = 1.1875F;
 				} else {
 					player.stepHeight = 0.5F;
 					playersWithStepup.remove(s);
 				}
 			} else if(shouldPlayerHaveStepup(player)) {
 				playersWithStepup.add(s);
-				player.stepHeight = 1F;
+				player.stepHeight = 1.1875F;
 			}
 		}
 	}

--- a/src/main/java/vazkii/quark/tweaks/feature/JumpBoostStepAssist.java
+++ b/src/main/java/vazkii/quark/tweaks/feature/JumpBoostStepAssist.java
@@ -46,14 +46,14 @@ public class JumpBoostStepAssist extends Feature {
 				if(shouldPlayerHaveStepup(player)) {
 					if(canToggleWithSneak && player.isSneaking())
 						player.stepHeight = 0.50001F; // Not 0.5F because that is the default
-					else player.stepHeight = 1.1875F;
+					else player.stepHeight = 1.25F;
 				} else {
 					player.stepHeight = 0.5F;
 					playersWithStepup.remove(s);
 				}
 			} else if(shouldPlayerHaveStepup(player)) {
 				playersWithStepup.add(s);
-				player.stepHeight = 1.1875F;
+				player.stepHeight = 1.25F;
 			}
 		}
 	}


### PR DESCRIPTION
1.25F is player jump height, which is what should ideally be used for step assist. This allows a player to step up to places where they would otherwise be able to jump to, such as a block with 2 layers of snow on top of it.

If there are other places in the code where this needs changing, feel free to close this PR and I'll open an issue for it to be dealt with later.