### PR TITLE
Fix Middle Clicking on Quark's Item Frames, Fixes #790

### DIFF
--- a/src/main/java/vazkii/quark/decoration/entity/EntityColoredItemFrame.java
+++ b/src/main/java/vazkii/quark/decoration/entity/EntityColoredItemFrame.java
@@ -30,6 +30,7 @@ import net.minecraft.network.datasync.EntityDataManager;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
 import net.minecraft.world.storage.MapData;
 import net.minecraftforge.fml.common.registry.IEntityAdditionalSpawnData;
@@ -64,6 +65,11 @@ public class EntityColoredItemFrame extends EntityFlatItemFrame {
 	@Override
 	protected void dropFrame() {
 		entityDropItem(new ItemStack(ColoredItemFrames.colored_item_frame, 1, getColor()), 0.0F);
+	}
+	
+	@Override
+	public ItemStack getPickedResult(RayTraceResult target) {
+		return new ItemStack(ColoredItemFrames.colored_item_frame, 1, getColor());
 	}
 
 	@Override

--- a/src/main/java/vazkii/quark/decoration/entity/EntityGlassItemFrame.java
+++ b/src/main/java/vazkii/quark/decoration/entity/EntityGlassItemFrame.java
@@ -3,6 +3,7 @@ package vazkii.quark.decoration.entity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
 import vazkii.quark.decoration.feature.ColoredItemFrames;
 import vazkii.quark.decoration.feature.GlassItemFrame;
@@ -22,4 +23,8 @@ public class EntityGlassItemFrame extends EntityFlatItemFrame {
 		entityDropItem(new ItemStack(GlassItemFrame.glass_item_frame, 1, 0), 0.0F);
 	}
 	
+	@Override
+	public ItemStack getPickedResult(RayTraceResult target) {
+		return new ItemStack(GlassItemFrame.glass_item_frame, 1, 0);
+	}
 }


### PR DESCRIPTION
- Overrides Entity:getPickedResult and returns the correct information.
- Fixes #790.
- Haha, sorry for misspelling the commit.