### PR TITLE
Torches shouldn't be allowed on the side of walls, Fixes #841

### DIFF
--- a/src/main/java/vazkii/quark/base/block/BlockQuarkWall.java
+++ b/src/main/java/vazkii/quark/base/block/BlockQuarkWall.java
@@ -18,6 +18,7 @@ import net.minecraft.block.BlockWall;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.properties.PropertyBool;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
@@ -135,6 +136,11 @@ public class BlockQuarkWall extends BlockMod implements IQuarkBlock {
 	@Override
 	protected BlockStateContainer createBlockState() {
 		return new BlockStateContainer(this, new IProperty[] {UP, NORTH, EAST, WEST, SOUTH});
+	}
+	
+	@Override
+	public BlockFaceShape getBlockFaceShape(IBlockAccess worldIn, IBlockState state, BlockPos pos, EnumFacing face) {
+		return face != EnumFacing.UP && face != EnumFacing.DOWN ? BlockFaceShape.MIDDLE_POLE_THICK : BlockFaceShape.CENTER_BIG;
 	}
 
 	@Override


### PR DESCRIPTION
- Override the method getBlockFaceShape, just like BlockWall does, and copy and pasted the logic, fixes #841.