### PR TITLE
Check if villager is capable of opening doors, fixes #921

### DIFF
--- a/src/main/java/vazkii/quark/tweaks/feature/DoubleDoors.java
+++ b/src/main/java/vazkii/quark/tweaks/feature/DoubleDoors.java
@@ -48,11 +48,12 @@ public class DoubleDoors extends Feature {
 				EntityAIBase te = it.next().action;
 				if(te instanceof EntityAIOpenDoubleDoor)
 					return;
-				else if(te instanceof EntityAIOpenDoor)
+				else if(te instanceof EntityAIOpenDoor) {
 					it.remove();
+					villager.tasks.addTask(4, new EntityAIOpenDoubleDoor(villager, true));
+					return;
+				}
 			}
-
-			villager.tasks.addTask(4, new EntityAIOpenDoubleDoor(villager, true));
 		}
 	}
 	


### PR DESCRIPTION
- Custom villager, that extended from EntityVillager, that coulnd't open doors were still getting injected 
with new ai and causing weird things to happen, fixes #921.
- Made it so that a villager can only be injected with the new ai is when it had the one being replaced.