### PR TITLE
Small tweaks to the panorama feature

### DIFF
--- a/src/main/java/vazkii/quark/client/feature/PanoramaMaker.java
+++ b/src/main/java/vazkii/quark/client/feature/PanoramaMaker.java
@@ -10,6 +10,7 @@
  */
 package vazkii.quark.client.feature;
 
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
@@ -34,6 +35,8 @@ import net.minecraft.client.renderer.texture.DynamicTexture;
 import net.minecraft.client.shader.Framebuffer;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.ScreenShotHelper;
+import net.minecraft.util.text.*;
+import net.minecraft.util.text.event.ClickEvent;
 import net.minecraftforge.client.event.GuiOpenEvent;
 import net.minecraftforge.client.event.ScreenshotEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -163,6 +166,10 @@ public class PanoramaMaker extends Feature {
 			currentDir.mkdirs();
 
 			event.setCanceled(true);
+			
+			ITextComponent panoramaDirComponent = new TextComponentString(currentDir.getName());
+			panoramaDirComponent.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_FILE, currentDir.getAbsolutePath())).setUnderlined(true);
+			event.setResultMessage(new TextComponentTranslation("quarkmisc.panoramaSaved", panoramaDirComponent));
 		}
 	}
 

--- a/src/main/java/vazkii/quark/client/feature/PanoramaMaker.java
+++ b/src/main/java/vazkii/quark/client/feature/PanoramaMaker.java
@@ -227,7 +227,7 @@ public class PanoramaMaker extends Feature {
 					takingPanorama = false;
 
 					mc.player.rotationYaw = rotationYaw;
-					mc.player.rotationPitch = rotationYaw;
+					mc.player.rotationPitch = rotationPitch;
 					mc.player.prevRotationYaw = mc.player.rotationYaw;
 					mc.player.prevRotationPitch = mc.player.rotationPitch;
 

--- a/src/main/resources/assets/quark/lang/en_US.lang
+++ b/src/main/resources/assets/quark/lang/en_US.lang
@@ -25,6 +25,7 @@ quarkmisc.signClear=Clear
 quarkmisc.rotationLockBefore=You have enabled Rotation Lock. Any blocks you place will be oriented in the direction you were looking. Press [
 quarkmisc.rotationLockAfter=] to change or reset it. This message won't appear again.
 quarkmisc.rightClickAdd=Right-click to Add
+quarkmisc.panoramaSaved=Saved panorama as %s
 
 # CONFIG STRINGS
 quark.config.title=Quark Configuration


### PR DESCRIPTION
This fixes two minor things:
* Fixes a small copypaste error where the player angle was reset incorrectly after taking the panorama.
* Previously, when taking a panorama, "Screenshot cancelled" would get printed to chat, since that is the message displayed when the screenshot event is cancelled (see vanilla ScreenShotHelper line 68,  forge ScreenshotEvent line 43). This PR changes the chat message to a much more vanilla style:
![image](https://user-images.githubusercontent.com/2068021/43622294-5ef0e352-96a9-11e8-9234-0f65ccc28bab.png)

You can even click on the text to open the folder containing the 6 screenshots.

While playing around with the panorama feature I thought my screenshots weren't being saved because of the confusing chat message! So I have like 20 identical panoramas now lmao