### PR TITLE
Register loot tables

### DIFF
--- a/src/main/java/vazkii/quark/world/entity/EntityWraith.java
+++ b/src/main/java/vazkii/quark/world/entity/EntityWraith.java
@@ -34,7 +34,7 @@ import net.minecraft.world.World;
 
 public class EntityWraith extends EntityZombie {
 
-	private static final ResourceLocation LOOT_TABLE = new ResourceLocation("quark:entities/wraith");
+	public static final ResourceLocation LOOT_TABLE = new ResourceLocation("quark:entities/wraith");
 
 	private static final DataParameter<Integer> SOUND_TYPE = EntityDataManager.<Integer>createKey(EntityWraith.class, DataSerializers.VARINT);
 	private static final String TAG_SOUND_TYPE = "SoundType";

--- a/src/main/java/vazkii/quark/world/feature/PirateShips.java
+++ b/src/main/java/vazkii/quark/world/feature/PirateShips.java
@@ -12,6 +12,7 @@ package vazkii.quark.world.feature;
 
 import net.minecraft.item.Item;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.storage.loot.LootTableList;
 import net.minecraftforge.fml.client.registry.RenderingRegistry;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.registry.EntityRegistry;
@@ -54,6 +55,7 @@ public class PirateShips extends Feature {
 		EntityRegistry.registerModEntity(new ResourceLocation(pirateName), EntityPirate.class, pirateName, LibEntityIDs.PIRATE, Quark.instance, 80, 3, true, 0x4d1d14, 0xac9617);
 
 		GameRegistry.registerWorldGenerator(new PirateShipGenerator(dims), 0);
+		LootTableList.register(PIRATE_CHEST_LOOT_TABLE);
 	}
 
 	@Override

--- a/src/main/java/vazkii/quark/world/feature/Wraiths.java
+++ b/src/main/java/vazkii/quark/world/feature/Wraiths.java
@@ -25,6 +25,7 @@ import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.gen.feature.WorldGenAbstractTree;
+import net.minecraft.world.storage.loot.LootTableList;
 import net.minecraftforge.common.BiomeDictionary;
 import net.minecraftforge.common.BiomeDictionary.Type;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent;
@@ -73,6 +74,7 @@ public class Wraiths extends Feature {
 
 		String wraithName = "quark:wraith";
 		EntityRegistry.registerModEntity(new ResourceLocation(wraithName), EntityWraith.class, wraithName, LibEntityIDs.WRAITH, Quark.instance, 80, 3, true, 0xececec, 0xbdbdbd);
+		LootTableList.register(EntityWraith.LOOT_TABLE);
 	}
 	
 	@Override


### PR DESCRIPTION
Vanilla registers all its built-in loot tables with `LootTableList.register()`. This PR registers Quark's loot tables the same way. Mods such as LootTweaker depend on this list to check whether built-in loot tables exist. 