### PR TITLE
Move broken Chisel IMC back to init. Actually fixes #1129

### DIFF
--- a/src/main/java/vazkii/quark/base/handler/ModIntegrationHandler.java
+++ b/src/main/java/vazkii/quark/base/handler/ModIntegrationHandler.java
@@ -13,13 +13,13 @@ public final class ModIntegrationHandler {
 
 	// disabled temporarily
 	public static void registerChiselVariant(String group, ItemStack stack) {
-//		NBTTagCompound cmp = new NBTTagCompound();
-//		cmp.setString("group", group);
-//		NBTTagCompound stackCmp = new NBTTagCompound();
-//		stack.writeToNBT(stackCmp);
-//		cmp.setTag("stack", stackCmp);
-//		
-//		FMLInterModComms.sendMessage("chisel", "add_variation", cmp);
+		NBTTagCompound cmp = new NBTTagCompound();
+		cmp.setString("group", group);
+		NBTTagCompound stackCmp = new NBTTagCompound();
+		stack.writeToNBT(stackCmp);
+		cmp.setTag("stack", stackCmp);
+
+		FMLInterModComms.sendMessage("chisel", "add_variation", cmp);
 	}
 	
 	public static void allowChiselAndBitsChiseling(Block b) {

--- a/src/main/java/vazkii/quark/base/handler/ModIntegrationHandler.java
+++ b/src/main/java/vazkii/quark/base/handler/ModIntegrationHandler.java
@@ -11,7 +11,6 @@ public final class ModIntegrationHandler {
 		FMLInterModComms.sendMessage("charset", "addCarry", b.getRegistryName());
 	}
 
-	// disabled temporarily
 	public static void registerChiselVariant(String group, ItemStack stack) {
 		NBTTagCompound cmp = new NBTTagCompound();
 		cmp.setString("group", group);

--- a/src/main/java/vazkii/quark/world/feature/RevampStoneGen.java
+++ b/src/main/java/vazkii/quark/world/feature/RevampStoneGen.java
@@ -142,18 +142,27 @@ public class RevampStoneGen extends Feature {
 		if(enableMarble) {
 			addOreDict("stoneMarble", ProxyRegistry.newStack(marble, 1, 0));
 			addOreDict("stoneMarblePolished", ProxyRegistry.newStack(marble, 1, 1));
-			ModIntegrationHandler.registerChiselVariant("marble", ProxyRegistry.newStack(marble, 1, 0));
-			ModIntegrationHandler.registerChiselVariant("marble", ProxyRegistry.newStack(marble, 1, 1));
 		}
 		
 		if(enableLimestone) {
 			addOreDict("stoneLimestone", ProxyRegistry.newStack(limestone, 1, 0));
 			addOreDict("stoneLimestonePolished", ProxyRegistry.newStack(limestone, 1, 1));
+		}
+	}
+
+	@Override
+	public void init(FMLInitializationEvent event) {
+		if(enableMarble) {
+			ModIntegrationHandler.registerChiselVariant("marble", ProxyRegistry.newStack(marble, 1, 0));
+			ModIntegrationHandler.registerChiselVariant("marble", ProxyRegistry.newStack(marble, 1, 1));
+		}
+
+		if(enableLimestone) {
 			ModIntegrationHandler.registerChiselVariant("limestone", ProxyRegistry.newStack(limestone, 1, 0));
 			ModIntegrationHandler.registerChiselVariant("limestone", ProxyRegistry.newStack(limestone, 1, 1));
 		}
 	}
-	
+
 	@SubscribeEvent
 	public void onOreGenerate(OreGenEvent.GenerateMinable event) {
 		switch(event.getType()) {


### PR DESCRIPTION
Turns out serializing stacks of unregistered items makes them air, so this didn't just break JEI but actually broke chiseling of those 4 block types, but no one actually looked at the chisel GUI itself to check that.