### PR TITLE
Add extra condition to block right click event

### DIFF
--- a/src/main/java/vazkii/quark/tweaks/feature/DoubleDoors.java
+++ b/src/main/java/vazkii/quark/tweaks/feature/DoubleDoors.java
@@ -59,7 +59,7 @@ public class DoubleDoors extends Feature {
 	
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public void onPlayerInteract(PlayerInteractEvent.RightClickBlock event) {
-		if(event.getEntityPlayer().isSneaking() || event.isCanceled() || event.getResult() == Result.DENY)
+		if(event.getEntityPlayer().isSneaking() || event.isCanceled() || event.getResult() == Result.DENY || event.getUseBlock() == Result.DENY)
 			return;
 
 		World world = event.getWorld();


### PR DESCRIPTION
There is an issue with my mod Locks. When a door is locked, the other can still be opened because I do not cancel the event completely, but rather deny the block use result, for which your mod doesn't account for. This small addition should fix the issue.