### PR TITLE
Fixed flat item frames only extending its model, when vanilla maps were placed in it

### DIFF
--- a/src/main/java/vazkii/quark/decoration/client/render/RenderFlatItemFrame.java
+++ b/src/main/java/vazkii/quark/decoration/client/render/RenderFlatItemFrame.java
@@ -102,8 +102,9 @@ public class RenderFlatItemFrame extends RenderItemFrame {
 		IBakedModel ibakedmodel;
 		BlockRendererDispatcher blockrendererdispatcher = mc.getBlockRendererDispatcher();
 		ModelManager modelmanager = blockrendererdispatcher.getBlockModelShapes().getModelManager();
+		ItemStack displayStack = entity.getDisplayedItem();
 
-		if(!entity.getDisplayedItem().isEmpty() && entity.getDisplayedItem().getItem() == Items.FILLED_MAP) {
+		if(!displayStack.isEmpty() && displayStack.getItem() instanceof net.minecraft.item.ItemMap && Items.FILLED_MAP.getMapData(displayStack, mc.world) != null) {
 			ibakedmodel = modelmanager.getModel(mapModel);
 		} else {
 			ibakedmodel = modelmanager.getModel(itemFrameModel);


### PR DESCRIPTION
Before fix:
![EL6Y1kY](https://user-images.githubusercontent.com/6305377/57988311-f838e880-7a8c-11e9-9f5a-5b80964254a7.png)
After fix:
![IPJGHb4](https://user-images.githubusercontent.com/6305377/57988322-2ae2e100-7a8d-11e9-90c2-65864c4ae43c.png)
(Left: Vanilla Map, Right: Modded map, extending ItemMap)