### PR TITLE
Fix NullPointerException on hitting entity with EntityDragonBreathBottle

### DIFF
--- a/src/main/java/vazkii/quark/misc/entity/EntityDragonBreathBottle.java
+++ b/src/main/java/vazkii/quark/misc/entity/EntityDragonBreathBottle.java
@@ -22,12 +22,17 @@ import java.util.stream.Collectors;
 
 public class EntityDragonBreathBottle extends EntityThrowable {
 
+	private static final int MAX_BOUNCE_COUNT = 3;
+	private int bounceCount;
+	
 	public EntityDragonBreathBottle(World world) {
 		super(world);
+		this.bounceCount = 0;
 	}
 
 	public EntityDragonBreathBottle(World world, EntityLivingBase entity) {
 		super(world, entity);
+		this.bounceCount = 0;
 	}
 
 	@Override

--- a/src/main/java/vazkii/quark/misc/entity/EntityDragonBreathBottle.java
+++ b/src/main/java/vazkii/quark/misc/entity/EntityDragonBreathBottle.java
@@ -41,9 +41,16 @@ public class EntityDragonBreathBottle extends EntityThrowable {
 			
 			if(result.typeOfHit != Type.BLOCK) {
 				
+				if(bounceCount >= MAX_BOUNCE_COUNT) {
+					this.setDead();
+					return;
+				}
+				
 				this.motionY *= -0.1;
 				this.motionY *= -0.1;
 				this.motionY *= -0.1;
+				
+				bounceCount += 1;
 				
 			}else {
 				

--- a/src/main/java/vazkii/quark/misc/entity/EntityDragonBreathBottle.java
+++ b/src/main/java/vazkii/quark/misc/entity/EntityDragonBreathBottle.java
@@ -31,17 +31,28 @@ public class EntityDragonBreathBottle extends EntityThrowable {
 	}
 
 	@Override
-	protected void onImpact(@Nonnull RayTraceResult pos) {
+	protected void onImpact(@Nonnull RayTraceResult result) {		
 		if(!world.isRemote) {
-			List<BlockPos> coordsList = getCoordsToPut(pos.getBlockPos());
-			for(BlockPos coords : coordsList) {
-				world.playEvent(2001, coords, Block.getStateId(world.getBlockState(coords)));
-				world.setBlockState(coords, Blocks.END_STONE.getDefaultState());
-			}
+			
+			if(result.typeOfHit != Type.BLOCK) {
+				
+				this.motionY *= -0.1;
+				this.motionY *= -0.1;
+				this.motionY *= -0.1;
+				
+			}else {
+				
+				List<BlockPos> coordsList = getCoordsToPut(result.getBlockPos());
+				for(BlockPos coords : coordsList) {
+					world.playEvent(2001, coords, Block.getStateId(world.getBlockState(coords)));
+					world.setBlockState(coords, Blocks.END_STONE.getDefaultState());
+				}
 
-			((WorldServer) world).spawnParticle(EnumParticleTypes.DRAGON_BREATH, posX, posY - 4, posZ, 500, 2, 2, 2, 0.03);
-			setDead();
-		}
+				((WorldServer) world).spawnParticle(EnumParticleTypes.DRAGON_BREATH, posX, posY - 4, posZ, 500, 2, 2, 2, 0.03);
+				setDead();
+				
+			}			
+		}		
 	}
 
 	private List<BlockPos> getCoordsToPut(BlockPos pos) {

--- a/src/main/java/vazkii/quark/misc/entity/EntityDragonBreathBottle.java
+++ b/src/main/java/vazkii/quark/misc/entity/EntityDragonBreathBottle.java
@@ -9,6 +9,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
+import net.minecraft.util.math.RayTraceResult.Type;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import vazkii.quark.misc.feature.ThrowableDragonBreath;


### PR DESCRIPTION
Hi,

If the EntityDragonBreathBottle hit another entity with the latest version of Quark, we have the next crash report.
[crash-2019-07-16_13.21.10-server.txt](https://github.com/Vazkii/Quark/files/3397501/crash-2019-07-16_13.21.10-server.txt)
I think my modification on the class fix it with no negative side effect.

Do not hesitate to tell me if changes are needed in what I did ! :smiley: 
Sorry for my hazardous English ^^


