### PR TITLE
Fixes DoubleDoor AI crashing if the door is removed in the same tick

### DIFF
--- a/src/main/java/vazkii/quark/tweaks/ai/EntityAIOpenDoubleDoor.java
+++ b/src/main/java/vazkii/quark/tweaks/ai/EntityAIOpenDoubleDoor.java
@@ -38,6 +38,8 @@ public class EntityAIOpenDoubleDoor extends EntityAIDoorInteract {
 		closingDoorTime = 20;
 
 		IBlockState state = entity.world.getBlockState(doorPosition).getActualState(entity.world, doorPosition);
+		if(state.getBlock() != doorBlock)
+			return;
 
 		EnumFacing direction = state.getValue(BlockDoor.FACING);
 		boolean isOpen = state.getValue(BlockDoor.OPEN);


### PR DESCRIPTION
Currently, if a door is removed during the same tick in which the AI task is executed, the game will crash, because it can't get the `BlockDoor.FACING` property anymore. This issue does not exist in Vanilla since they perform the same check that has been added in this commit in `BlockDoor::toggleDoor` before doing anything.

Unfortunately including a repro is quite difficult because of the required timing, but for completeness I have included the stacktrace of the relevant crash below. (The stacktrace originates from a version that is likely not the latest release and definitely not `master` but the issue persits on the current `master`.)

<details>
  <summary>Click to expand</summary><p>
Stacktrace:

```
java.lang.IllegalArgumentException: Cannot get property PropertyDirection{name=facing, clazz=class net.minecraft.util.EnumFacing, values=[north, south, west, east]} as it does not exist in BlockStateContainer{block=minecraft:air, properties=[]}
    at net.minecraft.block.state.BlockStateContainer$StateImplementation.func_177229_b(BlockStateContainer.java:201)
    at vazkii.quark.tweaks.ai.EntityAIOpenDoubleDoor.func_75251_c(EntityAIOpenDoubleDoor.java:63)
    at net.minecraft.entity.ai.EntityAITasks.func_75774_a(SourceFile:113)
    at net.minecraft.entity.EntityLiving.func_70626_be(EntityLiving.java:763)
    at net.minecraft.entity.EntityLivingBase.func_70636_d(EntityLivingBase.java:2352)
    at net.minecraft.entity.EntityLiving.func_70636_d(EntityLiving.java:577)
    at net.minecraft.entity.EntityAgeable.func_70636_d(EntityAgeable.java:178)
    at net.minecraft.entity.EntityLivingBase.func_70071_h_(EntityLivingBase.java:2172)
    at net.minecraft.entity.EntityLiving.func_70071_h_(EntityLiving.java:295)
    at net.minecraft.world.World.func_72866_a(World.java:1990)
    at net.minecraft.world.WorldServer.func_72866_a(WorldServer.java:832)
    at net.minecraft.world.World.func_72870_g(World.java:1952)
    at net.minecraft.world.World.func_72939_s(World.java:1756)
    at net.minecraft.world.WorldServer.func_72939_s(WorldServer.java:613)
    at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:767)
    at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:397)
    at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:668)
    at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:526)
    at java.lang.Thread.run(Unknown Source)
```
</p></details>