### PR TITLE
Make dyeing items with oredict dyes work properly

### DIFF
--- a/src/main/java/vazkii/quark/vanity/feature/DyeItemNames.java
+++ b/src/main/java/vazkii/quark/vanity/feature/DyeItemNames.java
@@ -72,7 +72,7 @@ public class DyeItemNames extends Feature {
 				if (!name.trim().isEmpty())
 					out.setStackDisplayName(name.trim());
 
-				ItemNBTHelper.setInt(out, TAG_DYE, right.getItemDamage());
+				ItemNBTHelper.setInt(out, TAG_DYE, meta);
 				event.setOutput(out);
 				event.setMaterialCost(1);
 				event.setCost(3);


### PR DESCRIPTION
Now the dye meta value from DyeUtils is actually applied to the item.

This fixes my own #1475 