### PR TITLE
Add JEI integration for elytra duping and anvil recipes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ repositories {
     }
     maven {
         // for JEI
-        name = "promwml16"
+        name "progwml6"
         url "http://dvs1.progwml6.com/files/maven"
     }
 }
@@ -91,6 +91,9 @@ dependencies {
     minecraft "net.minecraftforge:forge:${config.mc_version}-${config.forge_version}"
 
     compile fg.deobf("vazkii.arl:AutoRegLib:${config.arl_version}")
+
+    compileOnly fg.deobf("mezz.jei:jei-1.14.4:${config.jei_version}:api")
+    runtimeOnly fg.deobf("mezz.jei:jei-1.14.4:${config.jei_version}")
 }
 
 processResources {

--- a/build.properties
+++ b/build.properties
@@ -6,6 +6,7 @@ mapping_version=20191014-1.14.3
 mapping_channel=snapshot
 mod_id=quark
 arl_version=1.4-35.69
+jei_version=6.0.0.18
 version=beta-2.0
 dir_output=../Build Output/Quark/
 build_number=195

--- a/src/main/java/vazkii/quark/integration/jei/ElytraDuplicationExtension.java
+++ b/src/main/java/vazkii/quark/integration/jei/ElytraDuplicationExtension.java
@@ -1,0 +1,36 @@
+package vazkii.quark.integration.jei;
+
+import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.recipe.category.extensions.vanilla.crafting.ICraftingCategoryExtension;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.util.ResourceLocation;
+import vazkii.quark.tweaks.recipe.ElytraDuplicationRecipe;
+
+import javax.annotation.Nullable;
+
+public class ElytraDuplicationExtension implements ICraftingCategoryExtension {
+	private final ElytraDuplicationRecipe recipe;
+
+	ElytraDuplicationExtension(ElytraDuplicationRecipe recipe) {
+		this.recipe = recipe;
+	}
+
+	@Override
+	public void setIngredients(IIngredients ingredients) {
+		ingredients.setInputIngredients(recipe.getIngredients());
+		ingredients.setOutput(VanillaTypes.ITEM, recipe.getRecipeOutput());
+	}
+
+	@Override
+	public void drawInfo(int recipeWidth, int recipeHeight, double mouseX, double mouseY) {
+//		Minecraft.getInstance().fontRenderer.drawString(I18n.format("quark.jei.makes_copy"), 60, 46, 0x555555); TODO verify position once this is functional
+	}
+
+	@Nullable
+	@Override
+	public ResourceLocation getRegistryName() {
+		return recipe.getId();
+	}
+}

--- a/src/main/java/vazkii/quark/integration/jei/QuarkJeiPlugin.java
+++ b/src/main/java/vazkii/quark/integration/jei/QuarkJeiPlugin.java
@@ -1,0 +1,133 @@
+package vazkii.quark.integration.jei;
+
+import mezz.jei.api.IModPlugin;
+import mezz.jei.api.JeiPlugin;
+import mezz.jei.api.constants.VanillaRecipeCategoryUid;
+import mezz.jei.api.recipe.vanilla.IVanillaRecipeFactory;
+import mezz.jei.api.registration.IRecipeRegistration;
+import mezz.jei.api.registration.ISubtypeRegistration;
+import mezz.jei.api.registration.IVanillaCategoryExtensionRegistration;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentData;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.enchantment.Enchantments;
+import net.minecraft.item.EnchantedBookItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.util.ResourceLocation;
+import vazkii.arl.util.ItemNBTHelper;
+import vazkii.quark.base.Quark;
+import vazkii.quark.base.module.ModuleLoader;
+import vazkii.quark.tools.item.AncientTomeItem;
+import vazkii.quark.tools.module.AncientTomesModule;
+import vazkii.quark.tools.module.PickarangModule;
+import vazkii.quark.tweaks.recipe.ElytraDuplicationRecipe;
+import vazkii.quark.vanity.module.ColorRunesModule;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@JeiPlugin
+public class QuarkJeiPlugin implements IModPlugin {
+	private static final ResourceLocation UID = new ResourceLocation(Quark.MOD_ID, Quark.MOD_ID);
+
+	@Override
+	public ResourceLocation getPluginUid() {
+		return UID;
+	}
+
+	@Override
+	public void registerItemSubtypes(ISubtypeRegistration registration) {
+		registration.useNbtForSubtypes(AncientTomesModule.ancient_tome);
+	}
+
+	@Override
+	public void registerVanillaCategoryExtensions(IVanillaCategoryExtensionRegistration registration) { //TODO check if this works properly once JEI is fixed
+		registration.getCraftingCategory().addCategoryExtension(ElytraDuplicationRecipe.class, ElytraDuplicationExtension::new);
+	}
+
+	@Override
+	public void registerRecipes(IRecipeRegistration registration) {
+		IVanillaRecipeFactory factory = registration.getVanillaRecipeFactory();
+
+		if (ModuleLoader.INSTANCE.isModuleEnabled(AncientTomesModule.class))
+			registerAncientTomeAnvilRecipes(registration, factory);
+
+		if (ModuleLoader.INSTANCE.isModuleEnabled(ColorRunesModule.class))
+			registerRuneAnvilRecipes(registration, factory);
+
+		if (ModuleLoader.INSTANCE.isModuleEnabled(PickarangModule.class))
+			registerPickarangAnvilRepairs(registration, factory);
+	}
+
+	private void registerAncientTomeAnvilRecipes(IRecipeRegistration registration, IVanillaRecipeFactory factory) {
+		List<Object> recipes = new ArrayList<>();
+		for (Enchantment enchant : AncientTomesModule.validEnchants) {
+			EnchantmentData data = new EnchantmentData(enchant, enchant.getMaxLevel());
+			recipes.add(factory.createAnvilRecipe(EnchantedBookItem.getEnchantedItemStack(data),
+					Collections.singletonList(AncientTomeItem.getEnchantedItemStack(data)),
+					Collections.singletonList(EnchantedBookItem.getEnchantedItemStack(new EnchantmentData(data.enchantment, data.enchantmentLevel + 1)))));
+		}
+		registration.addRecipes(recipes, VanillaRecipeCategoryUid.ANVIL);
+	}
+
+	private void registerRuneAnvilRecipes(IRecipeRegistration registration, IVanillaRecipeFactory factory) {
+		Random random = new Random();
+		List<ItemStack> used = Stream.of(Items.DIAMOND_SWORD, Items.DIAMOND_PICKAXE, Items.DIAMOND_AXE,
+				Items.DIAMOND_SHOVEL, Items.DIAMOND_HOE, Items.DIAMOND_HELMET, Items.DIAMOND_CHESTPLATE,
+				Items.DIAMOND_LEGGINGS, Items.DIAMOND_BOOTS, Items.ELYTRA, Items.SHIELD, Items.BOW, Items.CROSSBOW,
+				Items.CARROT_ON_A_STICK, Items.FISHING_ROD, Items.SHEARS)
+				.map(item -> makeEnchantedDisplayItem(item, random))
+				.collect(Collectors.toList());
+
+		if (ModuleLoader.INSTANCE.isModuleEnabled(PickarangModule.class)) {
+			used.add(makeEnchantedDisplayItem(PickarangModule.pickarang, random));
+		}
+
+		List<Object> recipes = new ArrayList<>();
+		for (Item rune : ColorRunesModule.runesTag.getAllElements()) {
+			ItemStack runeStack = new ItemStack(rune);
+			recipes.add(factory.createAnvilRecipe(used, Collections.singletonList(runeStack),
+					used.stream().map(stack -> {
+						ItemStack output = stack.copy();
+						ItemNBTHelper.setBoolean(output, ColorRunesModule.TAG_RUNE_ATTACHED, true);
+						ItemNBTHelper.setCompound(output, ColorRunesModule.TAG_RUNE_COLOR, runeStack.serializeNBT());
+						return output;
+					}).collect(Collectors.toList())));
+		}
+		registration.addRecipes(recipes, VanillaRecipeCategoryUid.ANVIL);
+	}
+
+	private void registerPickarangAnvilRepairs(IRecipeRegistration registration, IVanillaRecipeFactory factory) {
+		//Repair ratios taken from JEI anvil maker
+		ItemStack nearlyBroken = new ItemStack(PickarangModule.pickarang);
+		nearlyBroken.setDamage(nearlyBroken.getMaxDamage());
+		ItemStack veryDamaged = nearlyBroken.copy();
+		veryDamaged.setDamage(veryDamaged.getMaxDamage() * 3 / 4);
+		ItemStack damaged = nearlyBroken.copy();
+		damaged.setDamage(damaged.getMaxDamage() * 2 / 4);
+
+		Object materialRepair = factory.createAnvilRecipe(nearlyBroken,
+				Collections.singletonList(new ItemStack(Items.DIAMOND)), Collections.singletonList(veryDamaged));
+		Object toolRepair = factory.createAnvilRecipe(veryDamaged,
+				Collections.singletonList(veryDamaged), Collections.singletonList(damaged));
+
+		registration.addRecipes(Arrays.asList(materialRepair, toolRepair), VanillaRecipeCategoryUid.ANVIL);
+	}
+
+	// Runes only show up and can be only anvilled on enchanted items, so make some random enchanted items
+	private static ItemStack makeEnchantedDisplayItem(Item input, Random random) {
+		ItemStack stack = new ItemStack(input);
+		if (input.getItemEnchantability() <= 0) { // If it can't take anything in ench. tables... 
+			stack.addEnchantment(Enchantments.UNBREAKING, 3); // it probably accepts unbreaking anyways
+			return stack;
+		}
+		return EnchantmentHelper.addRandomEnchantment(random, stack, 25, false);
+	}
+}

--- a/src/main/java/vazkii/quark/integration/jei/package-info.java
+++ b/src/main/java/vazkii/quark/integration/jei/package-info.java
@@ -1,0 +1,3 @@
+@javax.annotation.ParametersAreNonnullByDefault
+@mcp.MethodsReturnNonnullByDefault
+package vazkii.quark.integration.jei;

--- a/src/main/java/vazkii/quark/vanity/module/ColorRunesModule.java
+++ b/src/main/java/vazkii/quark/vanity/module/ColorRunesModule.java
@@ -40,7 +40,7 @@ public class ColorRunesModule extends Module {
 	public static final String TAG_RUNE_COLOR = Quark.MOD_ID + ":RuneColor";
 
 	private static final ThreadLocal<ItemStack> targetStack = new ThreadLocal<>();
-	private static Tag<Item> runesTag;
+	public static Tag<Item> runesTag;
 
 	@Config public static int dungeonWeight = 10;
 	@Config public static int netherFortressWeight = 8;

--- a/src/main/resources/assets/quark/lang/en_us.json
+++ b/src/main/resources/assets/quark/lang/en_us.json
@@ -16,6 +16,8 @@
 	"quark.gui.qbutton_info.back": "Back",
 	"quark.gui.qbutton_info": "Ingame configuration in newer versions of the game is currently not possible. For now, this will only open the config folder. You'll have to find \"quark-common.toml\" and open it. This is a text file, so you can open it with any text editor (such as Notepad). Changes to the file will apply in real time to your world when you save it.",
 	
+	"quark.jei.makes_copy": "Makes copy",
+	
 	"quark.keybind.change_hotbar": "Hotbar Swapper",
 	"quark.keybind.lock_rotation": "Rotation Lock",
 	"quark.keybind.sort_container": "Sort Target Inventory",


### PR DESCRIPTION
Anvil recipes supported are 
* ancient tomes + enchanted books
* runes + enchanted items, 
* repairing pickarangs.

Elytra duping doesn't show up due to a JEI bug (mezz/JustEnoughItems#1785) at the moment, so the "Makes copy" text isn't rendered yet as I can't verify the position. The position was copied from the 1.12 code.

JEI is not added to the toml as I don't think we use anything that wasn't in 6.0.