### PR TITLE
Added ignored screens from code

### DIFF
--- a/src/main/java/vazkii/quark/base/client/InventoryButtonHandler.java
+++ b/src/main/java/vazkii/quark/base/client/InventoryButtonHandler.java
@@ -42,7 +42,7 @@ public final class InventoryButtonHandler {
 		if(GeneralConfig.printScreenClassnames)
 			Quark.LOG.info("Opened screen {}", event.getGui().getClass().getName());
 		
-		if(event.getGui() instanceof ContainerScreen && !GeneralConfig.ignoredScreens.contains(event.getGui().getClass().getName())) {
+		if(event.getGui() instanceof ContainerScreen && !GeneralConfig.ignoredScreens.contains(event.getGui().getClass().getName()) && !GeneralConfig.ignoredScreensCode.contains(event.getGui().getClass().getName())) {
 			Minecraft mc = Minecraft.getInstance();
 			ContainerScreen<?> screen = (ContainerScreen<?>) event.getGui();
 

--- a/src/main/java/vazkii/quark/base/handler/GeneralConfig.java
+++ b/src/main/java/vazkii/quark/base/handler/GeneralConfig.java
@@ -53,6 +53,8 @@ public class GeneralConfig {
 	@Config(description = "Set to true to make the quark big worldgen features such as stone clusters or underground biomes generate as spheres rather than unique shapes. It's faster, but won't look as cool")
 	public static boolean useFastWorldgen = false;
 
+	public static List<String> ignoredScreensCode = Lists.newArrayList();
+
 	private GeneralConfig() {
 		// NO-OP
 	}

--- a/src/main/java/vazkii/quark/client/module/ChestSearchingModule.java
+++ b/src/main/java/vazkii/quark/client/module/ChestSearchingModule.java
@@ -79,7 +79,7 @@ public class ChestSearchingModule extends Module {
 	@OnlyIn(Dist.CLIENT)
 	public void initGui(GuiScreenEvent.InitGuiEvent.Post event) {
 		Screen gui = event.getGui();
-		if(gui instanceof ContainerScreen && !GeneralConfig.ignoredScreens.contains(event.getGui().getClass().getName())) {
+		if(gui instanceof ContainerScreen && !GeneralConfig.ignoredScreens.contains(event.getGui().getClass().getName()) && !GeneralConfig.ignoredScreensCode.contains(event.getGui().getClass().getName())) {
 			Minecraft mc = gui.getMinecraft();
 			ContainerScreen<?> chest = (ContainerScreen<?>) gui;
 			if(InventoryTransferHandler.accepts(chest.getContainer(), mc.player)) {


### PR DESCRIPTION
Simple code which can add support ignored screens from code. For authors mods who not want add buttons and not want support config.
Example: GeneralConfig.ignoredScreensCode.add("path.to.Screen");