### PR TITLE
Fix considerable overhead caused by uncached reflection.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,11 @@ jar {
     exclude "**/unused"
 
     manifest {
-        attributes("FMLCorePluginContainsFMLMod": "true", "FMLCorePlugin": "vazkii.quark.base.asm.LoadingPlugin")
+        attributes(
+                "FMLCorePluginContainsFMLMod": "true",
+                "FMLCorePlugin": "vazkii.quark.base.asm.LoadingPlugin",
+                "FMLAT": "quark_at.cfg"
+        )
     }
 
 }
@@ -89,6 +93,8 @@ processResources {
     from(sourceSets.main.resources.srcDirs) {
         exclude 'mcmod.info', '**/psd/**'
     }
+
+    rename '(.+_at.cfg)', 'META-INF/$1'
 }
 
 task deobfJar(type: Jar) {

--- a/src/main/java/vazkii/quark/client/feature/ItemsFlashBeforeExpiring.java
+++ b/src/main/java/vazkii/quark/client/feature/ItemsFlashBeforeExpiring.java
@@ -27,11 +27,11 @@ public class ItemsFlashBeforeExpiring extends Feature {
 	// Note: The following code, despite this being a client tweak, must run on servers! However, it doesn't affect clients without the tweak.
 
 	public static void setItemAge(EntityItem item, int age) {
-		ObfuscationReflectionHelper.setPrivateValue(EntityItem.class, item, age, "field_70292_b");
+		item.age = age;
 	}
 
 	public static int getItemAge(EntityItem item) {
-		return ObfuscationReflectionHelper.getPrivateValue(EntityItem.class, item, "field_70292_b");
+		return item.age;
 	}
 
 	private static final WeakHashMap<EntityItem, Integer> AGE_MAP = new WeakHashMap<>();

--- a/src/main/resources/quark_at.cfg
+++ b/src/main/resources/quark_at.cfg
@@ -1,0 +1,1 @@
+public net.minecraft.entity.item.EntityItem field_70292_b # age


### PR DESCRIPTION
My first instinct was to actually replace this with a proper cached
reflection call, but given the number of times that this is potentially
being called on a server with a large number of players (to the point
where it is causing `EntityItem::onUpdate` to take up around 7% of tick
time), this seems like the situation that access transformers were
**explicitly designed for**.

I feel as though even cached reflection would still add additional
overhead.

Especially given that this code is injected irregardless of the setting
being enabled (it being a client-side setting), speed would seem to be a
priority here.

Relevant profile:
![](https://i.imgur.com/u6Ngt0d.png)