### PR TITLE
Fix chest tags & recipes for newer chests

### DIFF
--- a/src/main/resources/data/forge/tags/blocks/chests/trapped.json
+++ b/src/main/resources/data/forge/tags/blocks/chests/trapped.json
@@ -6,6 +6,15 @@
     "quark:birch_trapped_chest",
     "quark:jungle_trapped_chest",
     "quark:acacia_trapped_chest",
-    "quark:dark_oak_trapped_chest"
+    "quark:dark_oak_trapped_chest",
+    "quark:nether_brick_trapped_chest",
+    "quark:purpur_trapped_chest",
+    "quark:prismarine_trapped_chest",
+    "quark:mushroom_trapped_chest",
+    "quark:willow_trapped_chest",
+    "quark:poise_trapped_chest",
+    "quark:bamboo_trapped_chest",
+    "quark:wisteria_trapped_chest",
+    "quark:driftwood_trapped_chest"
   ]
 }

--- a/src/main/resources/data/forge/tags/blocks/chests/wooden.json
+++ b/src/main/resources/data/forge/tags/blocks/chests/wooden.json
@@ -7,11 +7,21 @@
     "quark:jungle_chest",
     "quark:acacia_chest",
     "quark:dark_oak_chest",
+    "quark:willow_chest",
+    "quark:poise_chest",
+    "quark:bamboo_chest",
+    "quark:wisteria_chest",
+    "quark:driftwood_chest",
     "quark:oak_trapped_chest",
     "quark:spruce_trapped_chest",
     "quark:birch_trapped_chest",
     "quark:jungle_trapped_chest",
     "quark:acacia_trapped_chest",
-    "quark:dark_oak_trapped_chest"
+    "quark:dark_oak_trapped_chest",
+    "quark:willow_trapped_chest",
+    "quark:poise_trapped_chest",
+    "quark:bamboo_trapped_chest",
+    "quark:wisteria_trapped_chest",
+    "quark:driftwood_trapped_chest"
   ]
 }

--- a/src/main/resources/data/forge/tags/items/chests/trapped.json
+++ b/src/main/resources/data/forge/tags/items/chests/trapped.json
@@ -6,6 +6,15 @@
     "quark:birch_trapped_chest",
     "quark:jungle_trapped_chest",
     "quark:acacia_trapped_chest",
-    "quark:dark_oak_trapped_chest"
+    "quark:dark_oak_trapped_chest",
+    "quark:nether_brick_trapped_chest",
+    "quark:purpur_trapped_chest",
+    "quark:prismarine_trapped_chest",
+    "quark:mushroom_trapped_chest",
+    "quark:willow_trapped_chest",
+    "quark:poise_trapped_chest",
+    "quark:bamboo_trapped_chest",
+    "quark:wisteria_trapped_chest",
+    "quark:driftwood_trapped_chest"
   ]
 }

--- a/src/main/resources/data/forge/tags/items/chests/wooden.json
+++ b/src/main/resources/data/forge/tags/items/chests/wooden.json
@@ -7,11 +7,21 @@
     "quark:jungle_chest",
     "quark:acacia_chest",
     "quark:dark_oak_chest",
+    "quark:willow_chest",
+    "quark:poise_chest",
+    "quark:bamboo_chest",
+    "quark:wisteria_chest",
+    "quark:driftwood_chest",
     "quark:oak_trapped_chest",
     "quark:spruce_trapped_chest",
     "quark:birch_trapped_chest",
     "quark:jungle_trapped_chest",
     "quark:acacia_trapped_chest",
-    "quark:dark_oak_trapped_chest"
+    "quark:dark_oak_trapped_chest",
+    "quark:willow_trapped_chest",
+    "quark:poise_trapped_chest",
+    "quark:bamboo_trapped_chest",
+    "quark:wisteria_trapped_chest",
+    "quark:driftwood_trapped_chest"
   ]
 }

--- a/src/main/resources/data/quark/recipes/tweaks/crafting/utility/chests/compat/driftwood_chest_wood.json
+++ b/src/main/resources/data/quark/recipes/tweaks/crafting/utility/chests/compat/driftwood_chest_wood.json
@@ -8,7 +8,7 @@
   ],
   "key": {
     "#": {
-      "item": "upgrade_aquatic:driftwood_log"
+      "tag": "upgrade_aquatic:driftwood_logs"
     }
   },
   "result": {

--- a/src/main/resources/data/quark/recipes/tweaks/crafting/utility/chests/compat/poise_chest_wood.json
+++ b/src/main/resources/data/quark/recipes/tweaks/crafting/utility/chests/compat/poise_chest_wood.json
@@ -8,7 +8,7 @@
   ],
   "key": {
     "#": {
-      "item": "endergetic:poise_log"
+      "tag": "endergetic:poise_logs"
     }
   },
   "result": {

--- a/src/main/resources/data/quark/recipes/tweaks/crafting/utility/chests/compat/willow_chest_wood.json
+++ b/src/main/resources/data/quark/recipes/tweaks/crafting/utility/chests/compat/willow_chest_wood.json
@@ -8,7 +8,7 @@
   ],
   "key": {
     "#": {
-      "item": "swampexpansion:willow_log"
+      "tag": "swampexpansion:willow_logs"
     }
   },
   "result": {

--- a/src/main/resources/data/quark/recipes/tweaks/crafting/utility/chests/compat/wisteria_chest_wood.json
+++ b/src/main/resources/data/quark/recipes/tweaks/crafting/utility/chests/compat/wisteria_chest_wood.json
@@ -8,7 +8,7 @@
   ],
   "key": {
     "#": {
-      "item": "bloomful:wisteria_log"
+      "tag": "bloomful:wisteria_logs"
     }
   },
   "result": {


### PR DESCRIPTION
This Pull Request fixes the tags so that the wooden chest tag contains new compat chests, as does the trapped chest tag. It also makes the recipes using logs to get 4 chests work for compat chests.
Fixes #1821
Fixes #1822
Fixes #1825