### PR TITLE
Fix broken sign editing behavior when edit occurs after chunk reload

### DIFF
--- a/src/main/java/vazkii/quark/tweaks/module/SignEditingModule.java
+++ b/src/main/java/vazkii/quark/tweaks/module/SignEditingModule.java
@@ -60,6 +60,7 @@ public class SignEditingModule extends Module {
 
 			SignTileEntity sign = (SignTileEntity) tile;
 			sign.setPlayer(player);
+			sign.setEditable(true);
 
 			QuarkNetwork.sendToPlayer(new EditSignMessage(event.getPos()), (ServerPlayerEntity) player);
 		}


### PR DESCRIPTION
Fix sign edits not persisting if the sign is edited after the chunk it's in is reloaded. Fixes #2116. 

This fix also needs to be applied to 1.15.