### PR TITLE
Use method handles for loot table modification

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -17,8 +17,6 @@ public net.minecraft.client.gui.NewChatGui field_146250_j # scrollPos
 public net.minecraft.client.renderer.ItemRenderer func_180452_a(IIZ)V # setupGuiTransform
 public net.minecraft.entity.projectile.AbstractArrowEntity field_70254_i # inGround
 public net.minecraft.entity.ai.goal.GoalSelector field_220892_d # goals
-public net.minecraft.world.storage.loot.LootTable field_186466_c #pools
-public net.minecraft.world.storage.loot.LootPool field_186453_a # lootEntries
 public net.minecraft.client.renderer.color.BlockColors field_186725_a # colors
 public net.minecraft.client.renderer.entity.EntityRenderer field_188301_f # renderOutlines
 public net.minecraft.entity.ai.goal.TemptGoal func_188508_a(Lnet/minecraft/item/ItemStack;)Z # isTempting
@@ -44,5 +42,4 @@ public net.minecraft.client.renderer.RenderState field_228493_C_ #DEPTH_EQUAL
 public net.minecraft.client.renderer.RenderState field_228513_e_ #GLINT_TRANSPARENCY
 public net.minecraft.client.renderer.RenderState field_228526_r_ #GLINT_TEXTURING
 public net.minecraft.client.renderer.RenderState field_228527_s_ #ENTITY_GLINT_TEXTURING
-public net.minecraft.world.storage.loot.LootTable field_186466_c # pools
 public net.minecraft.tileentity.SignTileEntity field_145916_j # isEditable


### PR DESCRIPTION
This change is a workaround for an issue with the access transformer entries not being applied in IntelliJ IDEA (cause unknown, although I suspect it to be related to that fact that Forge patches both fields to change their types from arrays to lists). This also fixes the implementation where it previously had a redundant null check and didn't check the collection size before getting the 0th element.