### PR TITLE
Fix for #2235

### DIFF
--- a/src/main/java/vazkii/quark/management/capability/ShulkerBoxDropIn.java
+++ b/src/main/java/vazkii/quark/management/capability/ShulkerBoxDropIn.java
@@ -1,10 +1,11 @@
 package vazkii.quark.management.capability;
 
+import net.minecraft.block.Block;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.BlockItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
@@ -33,12 +34,16 @@ public class ShulkerBoxDropIn extends AbstractDropIn {
 
 		CompoundNBT cmp = ItemNBTHelper.getCompound(shulkerBox, "BlockEntityTag", false);
 		if (cmp != null) {
-			if (!cmp.contains("id", Constants.NBT.TAG_STRING)) {
-				cmp = cmp.copy();
-				cmp.putString("id", "minecraft:shulker_box");
+			TileEntity te = null;
+
+			if (shulkerBox.getItem() instanceof BlockItem) {
+				Block shulkerBoxBlock = Block.getBlockFromItem(shulkerBox.getItem());
+				if (shulkerBoxBlock.hasTileEntity()) {
+					te = shulkerBoxBlock.createTileEntity(null, null);
+					te.read(cmp);
+				}
 			}
 
-			TileEntity te = TileEntity.create(cmp);
 			if (te != null) {
 				LazyOptional<IItemHandler> handlerHolder = te.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null);
 				if (handlerHolder.isPresent()) {


### PR DESCRIPTION
TileEntity is created by the block itself now which allows Quark to use the TileEntity classes of other mods.

Changes have been tested on 1.15.2 with Forge version 31.1.18 client and Forge 31.2.0 server.
No more items get voided. Also normal shulkerboxes still work.

A nice extra is that it shows the full inventory for bigger shulkerboxes.