### PR TITLE
Re-implement realistic world type

### DIFF
--- a/src/main/java/vazkii/quark/world/client/RealisticGenScreen.java
+++ b/src/main/java/vazkii/quark/world/client/RealisticGenScreen.java
@@ -1,4 +1,6 @@
-package vazkii.quark.world.gen;
+package vazkii.quark.world.client;
+
+import vazkii.quark.world.gen.RealisticChunkGenerator;
 
 import net.minecraft.client.gui.screen.BiomeGeneratorTypeScreens;
 import net.minecraft.world.biome.provider.OverworldBiomeProvider;

--- a/src/main/java/vazkii/quark/world/gen/RealisticChunkGenerator.java
+++ b/src/main/java/vazkii/quark/world/gen/RealisticChunkGenerator.java
@@ -1,0 +1,108 @@
+package vazkii.quark.world.gen;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.provider.BiomeProvider;
+import net.minecraft.world.biome.provider.EndBiomeProvider;
+import net.minecraft.world.gen.DimensionSettings;
+import net.minecraft.world.gen.NoiseChunkGenerator;
+import net.minecraft.world.gen.settings.NoiseSettings;
+
+public class RealisticChunkGenerator extends NoiseChunkGenerator {
+	public static final Codec<RealisticChunkGenerator> CODEC = RecordCodecBuilder.create((instance) -> instance.group(
+			BiomeProvider.field_235202_a_.fieldOf("biome_source").forGetter(generator -> generator.biomeProvider),
+			Codec.LONG.fieldOf("seed").stable().forGetter(generator -> generator.seed),
+			DimensionSettings.field_236098_b_.fieldOf("settings").forGetter(generator -> generator.field_236080_h_))
+			.apply(instance, instance.stable(RealisticChunkGenerator::new)));
+	private final long seed;
+
+	public RealisticChunkGenerator(BiomeProvider biomeProvider, long seed, DimensionSettings settings) {
+		super(biomeProvider, seed, settings);
+		this.seed = seed;
+	}
+
+	@Override
+	public void fillNoiseColumn(double[] noiseColumn, int noiseX, int noiseZ) {
+		NoiseSettings settings = this.field_236080_h_.func_236113_b_();
+		double densityMax;
+		double variance;
+		if (this.field_236083_v_ != null) {
+			densityMax = EndBiomeProvider.func_235317_a_(this.field_236083_v_, noiseX, noiseZ) - 8.0F;
+			if (densityMax > 0.0D) {
+				variance = 0.25D;
+			} else {
+				variance = 1.0D;
+			}
+		} else {
+			float weightedScale = 0.0F;
+			float weightedDepth = 0.0F;
+			float weight = 0.0F;
+			int seaLevel = this.func_230356_f_();
+			float centerDepth = this.biomeProvider.getNoiseBiome(noiseX, seaLevel, noiseZ).getDepth();
+
+			// Biome interpolation
+			for(int localX = -2; localX <= 2; ++localX) {
+				for(int localZ = -2; localZ <= 2; ++localZ) {
+					Biome biome = this.biomeProvider.getNoiseBiome(noiseX + localX, seaLevel, noiseZ + localZ);
+					float depth = biome.getDepth();
+					float scale = biome.getScale();
+
+					float weightScale = depth > centerDepth ? 0.5F : 1.0F;
+					float weightAt = weightScale * field_236081_j_[localX + 2 + (localZ + 2) * 5] / (depth + 2.0F);
+					weightedScale += scale * weightAt;
+					weightedDepth += depth * weightAt;
+					weight += weightAt;
+				}
+			}
+
+			float scaledDepth = weightedDepth / weight;
+			float scaledScale = weightedScale / weight;
+			double finalDepth = (scaledDepth * 0.5F - 0.125F);
+			double finalScale = (scaledScale * 0.9F + 0.1F);
+			densityMax = finalDepth * 0.265625D;
+			variance = 107.04 / finalScale;
+		}
+
+		double horizontalNoiseScale = 175.0;
+		double verticalNoiseScale = 75.0;
+		double horizontalNoiseStretch = horizontalNoiseScale / 165.0;
+		double verticalNoiseStretch = verticalNoiseScale / 106.612;
+		double topTarget = settings.func_236172_c_().func_236186_a_();
+		double topSize = settings.func_236172_c_().func_236188_b_();
+		double topOffset = settings.func_236172_c_().func_236189_c_();
+		double bottomTarget = settings.func_236173_d_().func_236186_a_();
+		double bottomSize = settings.func_236173_d_().func_236188_b_();
+		double bottomOffset = settings.func_236173_d_().func_236189_c_();
+		double randomDensityOffset = settings.func_236179_j_() ? this.func_236095_c_(noiseX, noiseZ) : 0.0D;
+		double densityFactor = settings.func_236176_g_();
+		double densityOffset = settings.func_236177_h_();
+
+		for(int y = 0; y <= this.noiseSizeY; ++y) {
+			double noise = this.func_222552_a(noiseX, y, noiseZ, horizontalNoiseScale, verticalNoiseScale, horizontalNoiseStretch, verticalNoiseStretch);
+			double yOffset = 1.0D - (double) y * 2.0D / (double)this.noiseSizeY + randomDensityOffset;
+			double finalDensity = yOffset * densityFactor + densityOffset;
+			double falloff = (finalDensity + densityMax) * variance;
+			if (falloff > 0.0D) {
+				noise = noise + falloff * 4.0D;
+			} else {
+				noise = noise + falloff;
+			}
+
+			if (topSize > 0.0D) {
+				double target = ((double)(this.noiseSizeY - y) - topOffset) / topSize;
+				noise = MathHelper.clampedLerp(topTarget, noise, target);
+			}
+
+			if (bottomSize > 0.0D) {
+				double target = ((double) y - bottomOffset) / bottomSize;
+				noise = MathHelper.clampedLerp(bottomTarget, noise, target);
+			}
+
+			noiseColumn[y] = noise;
+		}
+
+	}
+}

--- a/src/main/java/vazkii/quark/world/gen/RealisticGenScreen.java
+++ b/src/main/java/vazkii/quark/world/gen/RealisticGenScreen.java
@@ -1,0 +1,19 @@
+package vazkii.quark.world.gen;
+
+import net.minecraft.client.gui.screen.BiomeGeneratorTypeScreens;
+import net.minecraft.world.biome.provider.OverworldBiomeProvider;
+import net.minecraft.world.gen.ChunkGenerator;
+import net.minecraft.world.gen.DimensionSettings;
+
+public class RealisticGenScreen extends BiomeGeneratorTypeScreens {
+
+	public RealisticGenScreen() {
+		super("quark.realistic");
+		field_239068_c_.add(this);
+	}
+
+	@Override
+	protected ChunkGenerator func_230484_a_(long seed) {
+		return new RealisticChunkGenerator(new OverworldBiomeProvider(seed, false, false), seed, DimensionSettings.Preset.field_236122_b_.func_236137_b_());
+	}
+}

--- a/src/main/java/vazkii/quark/world/module/RealisticWorldGenModule.java
+++ b/src/main/java/vazkii/quark/world/module/RealisticWorldGenModule.java
@@ -11,7 +11,7 @@ import vazkii.quark.base.module.LoadModule;
 import vazkii.quark.base.module.Module;
 import vazkii.quark.base.module.ModuleCategory;
 import vazkii.quark.world.gen.RealisticChunkGenerator;
-import vazkii.quark.world.gen.RealisticGenScreen;
+import vazkii.quark.world.client.RealisticGenScreen;
 
 import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.server.dedicated.ServerProperties;
@@ -31,6 +31,7 @@ public class RealisticWorldGenModule extends Module {
 		Registry.register(Registry.field_239690_aB_, new ResourceLocation("quark", "realistic"), RealisticChunkGenerator.CODEC);
 	}
 
+	@Override
 	@OnlyIn(Dist.CLIENT)
 	public void constructClient() {
 		new RealisticGenScreen();
@@ -50,10 +51,9 @@ public class RealisticWorldGenModule extends Module {
 			// If the world type is realistic, then replace the worldgen data
 			if (levelType.equals("realistic")) {
 				if (server.func_240793_aU_() instanceof ServerWorldInfo) {
-					ServerWorldInfo worldInfo  = (ServerWorldInfo)server.func_240793_aU_();
+					ServerWorldInfo worldInfo = (ServerWorldInfo)server.func_240793_aU_();
 					worldInfo.field_237343_c_ = createSettings(worldInfo.field_237343_c_.func_236221_b_(), worldInfo.field_237343_c_.func_236222_c_(), worldInfo.field_237343_c_.func_236223_d_());
 				}
-
 				ServerProperties properties = server.getServerProperties();
 				properties.field_241082_U_ = createSettings(properties.field_241082_U_.func_236221_b_(), properties.field_241082_U_.func_236222_c_(), properties.field_241082_U_.func_236223_d_());
 			}

--- a/src/main/java/vazkii/quark/world/module/RealisticWorldGenModule.java
+++ b/src/main/java/vazkii/quark/world/module/RealisticWorldGenModule.java
@@ -1,0 +1,26 @@
+package vazkii.quark.world.module;
+
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import vazkii.quark.base.module.LoadModule;
+import vazkii.quark.base.module.Module;
+import vazkii.quark.base.module.ModuleCategory;
+import vazkii.quark.world.gen.RealisticChunkGenerator;
+import vazkii.quark.world.gen.RealisticGenScreen;
+
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.registry.Registry;
+
+@LoadModule(category = ModuleCategory.WORLD)
+public class RealisticWorldGenModule extends Module {
+
+	@Override
+	public void construct() {
+		Registry.register(Registry.field_239690_aB_, new ResourceLocation("quark", "realistic"), RealisticChunkGenerator.CODEC);
+	}
+
+	@OnlyIn(Dist.CLIENT)
+	public void constructClient() {
+		new RealisticGenScreen();
+	}
+}

--- a/src/main/java/vazkii/quark/world/module/RealisticWorldGenModule.java
+++ b/src/main/java/vazkii/quark/world/module/RealisticWorldGenModule.java
@@ -1,17 +1,29 @@
 package vazkii.quark.world.module;
 
+import java.util.Locale;
+import java.util.Optional;
+
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.event.server.FMLServerAboutToStartEvent;
 import vazkii.quark.base.module.LoadModule;
 import vazkii.quark.base.module.Module;
 import vazkii.quark.base.module.ModuleCategory;
 import vazkii.quark.world.gen.RealisticChunkGenerator;
 import vazkii.quark.world.gen.RealisticGenScreen;
 
+import net.minecraft.server.dedicated.DedicatedServer;
+import net.minecraft.server.dedicated.ServerProperties;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.registry.Registry;
+import net.minecraft.world.DimensionType;
+import net.minecraft.world.biome.provider.OverworldBiomeProvider;
+import net.minecraft.world.gen.DimensionSettings;
+import net.minecraft.world.gen.settings.DimensionGeneratorSettings;
+import net.minecraft.world.storage.ServerWorldInfo;
 
-@LoadModule(category = ModuleCategory.WORLD)
+@LoadModule(category = ModuleCategory.WORLD, hasSubscriptions = true, subscribeOn = Dist.DEDICATED_SERVER)
 public class RealisticWorldGenModule extends Module {
 
 	@Override
@@ -22,5 +34,29 @@ public class RealisticWorldGenModule extends Module {
 	@OnlyIn(Dist.CLIENT)
 	public void constructClient() {
 		new RealisticGenScreen();
+	}
+
+	private static DimensionGeneratorSettings createSettings(long seed, boolean generateFeatures, boolean generateBonusChest) {
+		return new DimensionGeneratorSettings(seed, generateFeatures, generateBonusChest, DimensionGeneratorSettings.func_236216_a_(DimensionType.func_236022_a_(seed), new RealisticChunkGenerator(new OverworldBiomeProvider(seed, false, false), seed, DimensionSettings.Preset.field_236122_b_.func_236137_b_())));
+	}
+
+	@SubscribeEvent
+	public void onServerStart(FMLServerAboutToStartEvent event) {
+		// Check that we're on the dedicated server before checking the world type
+		if (event.getServer() instanceof DedicatedServer) {
+			DedicatedServer server = (DedicatedServer) event.getServer();
+			String levelType = Optional.ofNullable((String)server.getServerProperties().serverProperties.get("level-type")).map(str -> str.toLowerCase(Locale.ROOT)).orElse("default");
+
+			// If the world type is realistic, then replace the worldgen data
+			if (levelType.equals("realistic")) {
+				if (server.func_240793_aU_() instanceof ServerWorldInfo) {
+					ServerWorldInfo worldInfo  = (ServerWorldInfo)server.func_240793_aU_();
+					worldInfo.field_237343_c_ = createSettings(worldInfo.field_237343_c_.func_236221_b_(), worldInfo.field_237343_c_.func_236222_c_(), worldInfo.field_237343_c_.func_236223_d_());
+				}
+
+				ServerProperties properties = server.getServerProperties();
+				properties.field_241082_U_ = createSettings(properties.field_241082_U_.func_236221_b_(), properties.field_241082_U_.func_236222_c_(), properties.field_241082_U_.func_236223_d_());
+			}
+		}
 	}
 }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -55,3 +55,11 @@ public net.minecraft.world.server.ServerWorld func_73051_P()V # resetRainAndThun
 public net.minecraft.entity.projectile.ProjectileEntity <init>(Lnet/minecraft/entity/EntityType;Lnet/minecraft/world/World;)V
 public net.minecraft.client.renderer.entity.layers.BipedArmorLayer func_241736_a_(Lnet/minecraft/inventory/EquipmentSlotType;)Lnet/minecraft/client/renderer/entity/model/BipedModel; #func_241736_a_
 public net.minecraft.block.AbstractButtonBlock func_235471_c_()I # tickRate
+public-f net.minecraft.world.gen.NoiseChunkGenerator
+public net.minecraft.world.gen.NoiseChunkGenerator field_236083_v_ # islandNoise
+public net.minecraft.world.gen.NoiseChunkGenerator field_236081_j_ # biomeWeightTable
+public net.minecraft.world.gen.NoiseChunkGenerator field_222566_m # noiseSizeY
+public net.minecraft.world.gen.NoiseChunkGenerator func_222552_a(IIIDDDD)D # generateNoiseAt
+public net.minecraft.world.gen.NoiseChunkGenerator func_236095_c_(II)D # depthNoiseAt
+public net.minecraft.world.gen.NoiseChunkGenerator func_222548_a([DII)V # fillNoiseColumn
+public net.minecraft.client.gui.screen.BiomeGeneratorTypeScreens <init>(Ljava/lang/String;)V # BiomeGeneratorTypeScreens

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -63,3 +63,6 @@ public net.minecraft.world.gen.NoiseChunkGenerator func_222552_a(IIIDDDD)D # gen
 public net.minecraft.world.gen.NoiseChunkGenerator func_236095_c_(II)D # depthNoiseAt
 public net.minecraft.world.gen.NoiseChunkGenerator func_222548_a([DII)V # fillNoiseColumn
 public net.minecraft.client.gui.screen.BiomeGeneratorTypeScreens <init>(Ljava/lang/String;)V # BiomeGeneratorTypeScreens
+public net.minecraft.server.dedicated.PropertyManager field_73672_b # serverProperties
+public-f net.minecraft.world.storage.ServerWorldInfo field_237343_c_ # worldGenSettings
+public-f net.minecraft.server.dedicated.ServerProperties field_241082_U_ # worldGenSettings

--- a/src/main/resources/assets/quark/lang/en_us.json
+++ b/src/main/resources/assets/quark/lang/en_us.json
@@ -966,6 +966,7 @@
 	"block.quark.potted_sugar_cane": "Potted Sugar Cane",
 	"block.quark.potted_sunflower": "Potted Sunflower",
 	"block.quark.potted_wheat": "Potted Wheat",
-	"block.quark.potted_yellow_blossom_sapling": "Potted Sunny Blossom Sapling"
-	
+	"block.quark.potted_yellow_blossom_sapling": "Potted Sunny Blossom Sapling",
+
+	"generator.quark.realistic": "Quark Realistic"
 }


### PR DESCRIPTION
This PR re-implements the old realistic world type from previous quark versions. Unfortunately due to fundamental changes in the world generator, certain additions such as a larger river size and increased water lake rarity were not ported. Servers can use the realistic world type by setting the level-type value in the server.properties file to `realistic`.