### PR TITLE
Change Snow Bricks properties to be from Snow Blocks; Fixes #2396

### DIFF
--- a/src/main/java/vazkii/quark/building/module/MoreBrickTypesModule.java
+++ b/src/main/java/vazkii/quark/building/module/MoreBrickTypesModule.java
@@ -34,7 +34,7 @@ public class MoreBrickTypesModule extends Module {
 	@Override
 	public void construct() {
 		add("sandy", Blocks.SANDSTONE, () -> enableSandyBricks);
-		add("snow", Blocks.SNOW, () -> enableSnowBricks);
+		add("snow", Blocks.SNOW_BLOCK, () -> enableSnowBricks);
 		add("charred_nether", Blocks.NETHER_BRICKS, () -> enableCharredNetherBricks);
 		add("blue_nether", Blocks.NETHER_BRICKS, () -> enableBlueNetherBricks);
 		add("sandstone", Blocks.SANDSTONE, () -> enableSandstoneBricks);


### PR DESCRIPTION
Snow Bricks were getting their properties from snow, which is the layered version, not Snow Blocks