### PR TITLE
Simplify BigDungeonChestProcessor loot table code. (1.16)

### DIFF
--- a/src/main/java/vazkii/quark/world/gen/structure/processor/BigDungeonChestProcessor.java
+++ b/src/main/java/vazkii/quark/world/gen/structure/processor/BigDungeonChestProcessor.java
@@ -31,18 +31,10 @@ public class BigDungeonChestProcessor extends StructureProcessor {
     		Random rand = placementSettingsIn.getRandom(blockInfo.pos);
     		if(rand.nextDouble() > BigDungeonModule.chestChance)
 	            return new BlockInfo(blockInfo.pos, Blocks.CAVE_AIR.getDefaultState(), new CompoundNBT());
-    		
-    		TileEntity tile = TileEntity.func_235657_b_(blockInfo.state, blockInfo.nbt); // create
-    		if(tile instanceof ChestTileEntity) {
-    			ChestTileEntity chest = (ChestTileEntity) tile;
-    			chest.setLootTable(null, 0);
-    			for(int i = 0; i < chest.getSizeInventory(); i++)
-    				chest.setInventorySlotContents(i, ItemStack.EMPTY);
-    			
-    			chest.setLootTable(new ResourceLocation(BigDungeonModule.lootTable), rand.nextLong());
-    			CompoundNBT nbt = new CompoundNBT();
-    			chest.write(nbt);
-    			return new BlockInfo(blockInfo.pos, blockInfo.state, nbt);
+    		if (blockInfo.nbt.getString("id").equals("minecraft:chest")) {
+    			blockInfo.nbt.putString("LootTable", BigDungeonModule.lootTable);
+    			blockInfo.nbt.putLong("LootTableSeed", rand.nextLong());
+    			return new BlockInfo(blockInfo.pos, blockInfo.state, blockInfo.nbt);
     		}
     	}
     	


### PR DESCRIPTION
This code creates an inherently worldless tile entity (which can become
problematic with `fillWithLoot`), sets a null loot table (when the
default is already null), replaces the contents with empty item stacks
(when they should in theory already be null), and then sets the loot
table.

It then serializes the tile entity back to NBT and returns it.

Given that we have access to the tile entity NBT originally, it's a
simple matter of comparing the type to `minecraft:chest` and, if so,
setting the `LootTable` and `LootTableSeed` values for the NBT compound.

This commit simplifies the code to do precisely that: check for a chest,
set the relevant loot table and add a seed, and then return a new(?)
BlockInfo containing those. I'm unsure if returning the original
BlockInfo with the modified NBT would be sufficient also.