### PR TITLE
Removed Filter Buttons from RS Crafting Grid

### DIFF
--- a/src/main/java/vazkii/quark/base/handler/GeneralConfig.java
+++ b/src/main/java/vazkii/quark/base/handler/GeneralConfig.java
@@ -45,9 +45,7 @@ public class GeneralConfig {
 	@Config(description = "A list of screens that don't play well with quark's buttons. Use \"Print Screen Classnames\" to find the names of any others you'd want to add.")
 	public static List<String> ignoredScreens = Lists.newArrayList(
 			"com.tfar.craftingstation.client.CraftingStationScreen",
-			"com.raoulvdberge.refinedstorage.screen.grid.GridScreen",
-			"com.raoulvdberge.refinedstorage.screen.DiskManipulatorScreen",
-			"com.raoulvdberge.refinedstorage.screen.InterfaceScreen", 
+			"com.refinedmods.refinedstorage.screen.grid.GridScreen", 
 			"appeng.client.gui.implementations.CraftingTermScreen", 
 			"appeng.client.gui.implementations.PatternTermScreen"
 			);


### PR DESCRIPTION
The Crafting Grid was not being ignored, because of a refactor in Refined Storage, with this config change it will be correctly ignored once again.

This change has been verified in-game.