### PR TITLE
Added conduit support for elder prismarine

### DIFF
--- a/src/main/java/vazkii/quark/world/block/ElderPrismarineBlock.java
+++ b/src/main/java/vazkii/quark/world/block/ElderPrismarineBlock.java
@@ -1,0 +1,21 @@
+package vazkii.quark.world.block;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.item.ItemGroup;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IWorldReader;
+import vazkii.quark.base.block.QuarkBlock;
+import vazkii.quark.base.module.Module;
+
+public class ElderPrismarineBlock extends QuarkBlock {
+
+	public ElderPrismarineBlock(String regname, Module module, ItemGroup creativeTab, Properties properties) {
+		super(regname, module, creativeTab, properties);
+	}
+	
+	@Override
+	public boolean isConduitFrame(BlockState state, IWorldReader world, BlockPos pos, BlockPos conduit) {
+		return true;
+	}
+
+}

--- a/src/main/java/vazkii/quark/world/module/underground/ElderPrismarineUndergroundBiomeModule.java
+++ b/src/main/java/vazkii/quark/world/module/underground/ElderPrismarineUndergroundBiomeModule.java
@@ -12,6 +12,7 @@ import vazkii.quark.base.handler.VariantHandler;
 import vazkii.quark.base.module.Config;
 import vazkii.quark.base.module.LoadModule;
 import vazkii.quark.base.module.ModuleCategory;
+import vazkii.quark.world.block.ElderPrismarineBlock;
 import vazkii.quark.world.config.UndergroundBiomeConfig;
 import vazkii.quark.world.gen.underground.ElderPrismarineUndergroundBiome;
 
@@ -33,7 +34,7 @@ public class ElderPrismarineUndergroundBiomeModule extends UndergroundBiomeModul
 
     @Override
 	public void construct() {
-		elder_prismarine = new QuarkBlock("elder_prismarine", this, ItemGroup.BUILDING_BLOCKS, 
+		elder_prismarine = new ElderPrismarineBlock("elder_prismarine", this, ItemGroup.BUILDING_BLOCKS, 
 				Block.Properties.create(Material.ROCK, MaterialColor.ADOBE)
 				.func_235861_h_() // needs tool
         		.harvestTool(ToolType.PICKAXE)
@@ -41,8 +42,8 @@ public class ElderPrismarineUndergroundBiomeModule extends UndergroundBiomeModul
 				.sound(SoundType.STONE));
 		
 		VariantHandler.addSlabStairsWall(elder_prismarine);
-		VariantHandler.addSlabAndStairs(new QuarkBlock("elder_prismarine_bricks", this, ItemGroup.BUILDING_BLOCKS, Block.Properties.from(elder_prismarine)));
-		VariantHandler.addSlabAndStairs(new QuarkBlock("dark_elder_prismarine", this, ItemGroup.BUILDING_BLOCKS, Block.Properties.from(elder_prismarine)));
+		VariantHandler.addSlabAndStairs(new ElderPrismarineBlock("elder_prismarine_bricks", this, ItemGroup.BUILDING_BLOCKS, Block.Properties.from(elder_prismarine)));
+		VariantHandler.addSlabAndStairs(new ElderPrismarineBlock("dark_elder_prismarine", this, ItemGroup.BUILDING_BLOCKS, Block.Properties.from(elder_prismarine)));
 		
 		elder_sea_lantern = new QuarkBlock("elder_sea_lantern", this, ItemGroup.BUILDING_BLOCKS, 
 				Block.Properties.create(Material.GLASS, MaterialColor.ADOBE)


### PR DESCRIPTION
Closes #1574. Adds a new class, ElderPrismarineBlock, which extends QuarkBlock and returns true for isConduitFrame, and changes the elder prismarine blocks to use this class instead.