### PR TITLE
Fix coordinate typo in SlimeInABucketItem

### DIFF
--- a/src/main/java/vazkii/quark/tools/item/SlimeInABucketItem.java
+++ b/src/main/java/vazkii/quark/tools/item/SlimeInABucketItem.java
@@ -48,7 +48,7 @@ public class SlimeInABucketItem extends QuarkItem {
 		if(world instanceof ServerWorld) {
 			Vector3d pos = entity.getPositionVec();
 			int x = MathHelper.floor(pos.x);
-			int z = MathHelper.floor(pos.x);
+			int z = MathHelper.floor(pos.z);
 			boolean slime = isSlimeChunk((ServerWorld) world, x, z);
 			boolean excited = ItemNBTHelper.getBoolean(stack, TAG_EXCITED, false);
 			if(excited != slime)


### PR DESCRIPTION
Not tested, but just something I saw while reviewing from github

Might fix #1998