### PR TITLE
Allow for vertical planks to be used in more recipes

### DIFF
--- a/src/main/resources/data/minecraft/recipes/acacia_boat.json
+++ b/src/main/resources/data/minecraft/recipes/acacia_boat.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "boat",
+  "pattern": [
+    "# #",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:acacia_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:acacia_boat"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/acacia_boat.json
+++ b/src/main/resources/data/minecraft/recipes/acacia_boat.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:acacia_planks"
+      "tag": "quark:acacia_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/acacia_button.json
+++ b/src/main/resources/data/minecraft/recipes/acacia_button.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "group": "wooden_button",
+  "ingredients": [
+    {
+      "item": "minecraft:acacia_planks"
+    }
+  ],
+  "result": {
+    "item": "minecraft:acacia_button"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/acacia_button.json
+++ b/src/main/resources/data/minecraft/recipes/acacia_button.json
@@ -3,7 +3,7 @@
   "group": "wooden_button",
   "ingredients": [
     {
-      "item": "minecraft:acacia_planks"
+      "tag": "quark:acacia_planks"
     }
   ],
   "result": {

--- a/src/main/resources/data/minecraft/recipes/acacia_door.json
+++ b/src/main/resources/data/minecraft/recipes/acacia_door.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_door",
+  "pattern": [
+    "##",
+    "##",
+    "##"
+  ],
+  "key": {
+    "#": {
+      "tag": "quark:acacia_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:acacia_door",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/acacia_fence.json
+++ b/src/main/resources/data/minecraft/recipes/acacia_fence.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_fence",
+  "pattern": [
+    "W#W",
+    "W#W"
+  ],
+  "key": {
+    "#": {
+      "tag": "forge:rods/wooden"
+    },
+    "W": {
+      "tag": "quark:acacia_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:acacia_fence",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/acacia_fence_gate.json
+++ b/src/main/resources/data/minecraft/recipes/acacia_fence_gate.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_fence_gate",
+  "pattern": [
+    "#W#",
+    "#W#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stick"
+    },
+    "W": {
+      "item": "minecraft:acacia_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:acacia_fence_gate"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/acacia_fence_gate.json
+++ b/src/main/resources/data/minecraft/recipes/acacia_fence_gate.json
@@ -7,10 +7,10 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:stick"
+      "tag": "forge:rods/wooden"
     },
     "W": {
-      "item": "minecraft:acacia_planks"
+      "tag": "quark:acacia_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/acacia_pressure_plate.json
+++ b/src/main/resources/data/minecraft/recipes/acacia_pressure_plate.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_pressure_plate",
+  "pattern": [
+    "##"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:acacia_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:acacia_pressure_plate"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/acacia_pressure_plate.json
+++ b/src/main/resources/data/minecraft/recipes/acacia_pressure_plate.json
@@ -6,7 +6,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:acacia_planks"
+      "tag": "quark:acacia_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/acacia_sign.json
+++ b/src/main/resources/data/minecraft/recipes/acacia_sign.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "sign",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:acacia_planks"
+    },
+    "X": {
+      "item": "minecraft:stick"
+    }
+  },
+  "result": {
+    "item": "minecraft:acacia_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/acacia_sign.json
+++ b/src/main/resources/data/minecraft/recipes/acacia_sign.json
@@ -8,10 +8,10 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:acacia_planks"
+      "tag": "quark:acacia_planks"
     },
     "X": {
-      "item": "minecraft:stick"
+      "tag": "forge:rods/wooden"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/acacia_slab.json
+++ b/src/main/resources/data/minecraft/recipes/acacia_slab.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_slab",
+  "pattern": [
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:acacia_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:acacia_slab",
+    "count": 6
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/acacia_slab.json
+++ b/src/main/resources/data/minecraft/recipes/acacia_slab.json
@@ -6,7 +6,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:acacia_planks"
+      "tag": "quark:acacia_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/acacia_stairs.json
+++ b/src/main/resources/data/minecraft/recipes/acacia_stairs.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_stairs",
+  "pattern": [
+    "#  ",
+    "## ",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:acacia_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:acacia_stairs",
+    "count": 4
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/acacia_stairs.json
+++ b/src/main/resources/data/minecraft/recipes/acacia_stairs.json
@@ -8,7 +8,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:acacia_planks"
+      "tag": "quark:acacia_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/acacia_trapdoor.json
+++ b/src/main/resources/data/minecraft/recipes/acacia_trapdoor.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_trapdoor",
+  "pattern": [
+    "###",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:acacia_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:acacia_trapdoor",
+    "count": 2
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/acacia_trapdoor.json
+++ b/src/main/resources/data/minecraft/recipes/acacia_trapdoor.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:acacia_planks"
+      "tag": "quark:acacia_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/birch_boat.json
+++ b/src/main/resources/data/minecraft/recipes/birch_boat.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "boat",
+  "pattern": [
+    "# #",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:birch_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:birch_boat"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/birch_boat.json
+++ b/src/main/resources/data/minecraft/recipes/birch_boat.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:birch_planks"
+      "tag": "quark:birch_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/birch_button.json
+++ b/src/main/resources/data/minecraft/recipes/birch_button.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "group": "wooden_button",
+  "ingredients": [
+    {
+      "item": "minecraft:birch_planks"
+    }
+  ],
+  "result": {
+    "item": "minecraft:birch_button"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/birch_button.json
+++ b/src/main/resources/data/minecraft/recipes/birch_button.json
@@ -3,7 +3,7 @@
   "group": "wooden_button",
   "ingredients": [
     {
-      "item": "minecraft:birch_planks"
+      "tag": "quark:birch_planks"
     }
   ],
   "result": {

--- a/src/main/resources/data/minecraft/recipes/birch_door.json
+++ b/src/main/resources/data/minecraft/recipes/birch_door.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_door",
+  "pattern": [
+    "##",
+    "##",
+    "##"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:birch_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:birch_door",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/birch_door.json
+++ b/src/main/resources/data/minecraft/recipes/birch_door.json
@@ -8,7 +8,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:birch_planks"
+      "tag": "quark:birch_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/birch_fence.json
+++ b/src/main/resources/data/minecraft/recipes/birch_fence.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_fence",
+  "pattern": [
+    "W#W",
+    "W#W"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stick"
+    },
+    "W": {
+      "item": "minecraft:birch_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:birch_fence",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/birch_fence.json
+++ b/src/main/resources/data/minecraft/recipes/birch_fence.json
@@ -7,10 +7,10 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:stick"
+      "tag": "forge:rods/wooden"
     },
     "W": {
-      "item": "minecraft:birch_planks"
+      "tag": "quark:birch_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/birch_fence_gate.json
+++ b/src/main/resources/data/minecraft/recipes/birch_fence_gate.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_fence_gate",
+  "pattern": [
+    "#W#",
+    "#W#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stick"
+    },
+    "W": {
+      "item": "minecraft:birch_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:birch_fence_gate"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/birch_fence_gate.json
+++ b/src/main/resources/data/minecraft/recipes/birch_fence_gate.json
@@ -7,10 +7,10 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:stick"
+      "tag": "forge:rods/wooden"
     },
     "W": {
-      "item": "minecraft:birch_planks"
+      "tag": "quark:birch_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/birch_pressure_plate.json
+++ b/src/main/resources/data/minecraft/recipes/birch_pressure_plate.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_pressure_plate",
+  "pattern": [
+    "##"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:birch_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:birch_pressure_plate"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/birch_pressure_plate.json
+++ b/src/main/resources/data/minecraft/recipes/birch_pressure_plate.json
@@ -6,7 +6,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:birch_planks"
+      "tag": "quark:birch_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/birch_sign.json
+++ b/src/main/resources/data/minecraft/recipes/birch_sign.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "sign",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:birch_planks"
+    },
+    "X": {
+      "item": "minecraft:stick"
+    }
+  },
+  "result": {
+    "item": "minecraft:birch_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/birch_sign.json
+++ b/src/main/resources/data/minecraft/recipes/birch_sign.json
@@ -8,10 +8,10 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:birch_planks"
+      "tag": "quark:birch_planks"
     },
     "X": {
-      "item": "minecraft:stick"
+      "tag": "forge:rods/wooden"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/birch_slab.json
+++ b/src/main/resources/data/minecraft/recipes/birch_slab.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_slab",
+  "pattern": [
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:birch_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:birch_slab",
+    "count": 6
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/birch_slab.json
+++ b/src/main/resources/data/minecraft/recipes/birch_slab.json
@@ -6,7 +6,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:birch_planks"
+      "tag": "quark:birch_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/birch_stairs.json
+++ b/src/main/resources/data/minecraft/recipes/birch_stairs.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_stairs",
+  "pattern": [
+    "#  ",
+    "## ",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:birch_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:birch_stairs",
+    "count": 4
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/birch_stairs.json
+++ b/src/main/resources/data/minecraft/recipes/birch_stairs.json
@@ -8,7 +8,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:birch_planks"
+      "tag": "quark:birch_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/birch_trapdoor.json
+++ b/src/main/resources/data/minecraft/recipes/birch_trapdoor.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_trapdoor",
+  "pattern": [
+    "###",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:birch_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:birch_trapdoor",
+    "count": 2
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/birch_trapdoor.json
+++ b/src/main/resources/data/minecraft/recipes/birch_trapdoor.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:birch_planks"
+      "tag": "quark:birch_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/crimson_button.json
+++ b/src/main/resources/data/minecraft/recipes/crimson_button.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "group": "wooden_button",
+  "ingredients": [
+    {
+      "item": "minecraft:crimson_planks"
+    }
+  ],
+  "result": {
+    "item": "minecraft:crimson_button"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/crimson_button.json
+++ b/src/main/resources/data/minecraft/recipes/crimson_button.json
@@ -3,7 +3,7 @@
   "group": "wooden_button",
   "ingredients": [
     {
-      "item": "minecraft:crimson_planks"
+      "tag": "quark:crimson_planks"
     }
   ],
   "result": {

--- a/src/main/resources/data/minecraft/recipes/crimson_door.json
+++ b/src/main/resources/data/minecraft/recipes/crimson_door.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_door",
+  "pattern": [
+    "##",
+    "##",
+    "##"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:crimson_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:crimson_door",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/crimson_door.json
+++ b/src/main/resources/data/minecraft/recipes/crimson_door.json
@@ -8,7 +8,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:crimson_planks"
+      "tag": "quark:crimson_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/crimson_fence.json
+++ b/src/main/resources/data/minecraft/recipes/crimson_fence.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_fence",
+  "pattern": [
+    "W#W",
+    "W#W"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stick"
+    },
+    "W": {
+      "item": "minecraft:crimson_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:crimson_fence",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/crimson_fence.json
+++ b/src/main/resources/data/minecraft/recipes/crimson_fence.json
@@ -7,10 +7,10 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:stick"
+      "tag": "forge:rods/wooden"
     },
     "W": {
-      "item": "minecraft:crimson_planks"
+      "tag": "quark:crimson_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/crimson_fence_gate.json
+++ b/src/main/resources/data/minecraft/recipes/crimson_fence_gate.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_fence_gate",
+  "pattern": [
+    "#W#",
+    "#W#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stick"
+    },
+    "W": {
+      "item": "minecraft:crimson_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:crimson_fence_gate"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/crimson_fence_gate.json
+++ b/src/main/resources/data/minecraft/recipes/crimson_fence_gate.json
@@ -7,10 +7,10 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:stick"
+      "tag": "forge:rods/wooden"
     },
     "W": {
-      "item": "minecraft:crimson_planks"
+      "tag": "quark:crimson_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/crimson_pressure_plate.json
+++ b/src/main/resources/data/minecraft/recipes/crimson_pressure_plate.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_pressure_plate",
+  "pattern": [
+    "##"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:crimson_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:crimson_pressure_plate"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/crimson_pressure_plate.json
+++ b/src/main/resources/data/minecraft/recipes/crimson_pressure_plate.json
@@ -6,7 +6,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:crimson_planks"
+      "tag": "quark:crimson_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/crimson_sign.json
+++ b/src/main/resources/data/minecraft/recipes/crimson_sign.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "sign",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:crimson_planks"
+    },
+    "X": {
+      "item": "minecraft:stick"
+    }
+  },
+  "result": {
+    "item": "minecraft:crimson_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/crimson_sign.json
+++ b/src/main/resources/data/minecraft/recipes/crimson_sign.json
@@ -8,10 +8,10 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:crimson_planks"
+      "tag": "quark:crimson_planks"
     },
     "X": {
-      "item": "minecraft:stick"
+      "tag": "forge:rods/wooden"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/crimson_slab.json
+++ b/src/main/resources/data/minecraft/recipes/crimson_slab.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_slab",
+  "pattern": [
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:crimson_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:crimson_slab",
+    "count": 6
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/crimson_slab.json
+++ b/src/main/resources/data/minecraft/recipes/crimson_slab.json
@@ -6,7 +6,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:crimson_planks"
+      "tag": "quark:crimson_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/crimson_stairs.json
+++ b/src/main/resources/data/minecraft/recipes/crimson_stairs.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_stairs",
+  "pattern": [
+    "#  ",
+    "## ",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:crimson_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:crimson_stairs",
+    "count": 4
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/crimson_stairs.json
+++ b/src/main/resources/data/minecraft/recipes/crimson_stairs.json
@@ -8,7 +8,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:crimson_planks"
+      "tag": "quark:crimson_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/crimson_trapdoor.json
+++ b/src/main/resources/data/minecraft/recipes/crimson_trapdoor.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_trapdoor",
+  "pattern": [
+    "###",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:crimson_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:crimson_trapdoor",
+    "count": 2
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/crimson_trapdoor.json
+++ b/src/main/resources/data/minecraft/recipes/crimson_trapdoor.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:crimson_planks"
+      "tag": "quark:crimson_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/dark_oak_boat.json
+++ b/src/main/resources/data/minecraft/recipes/dark_oak_boat.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "boat",
+  "pattern": [
+    "# #",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:dark_oak_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:dark_oak_boat"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/dark_oak_boat.json
+++ b/src/main/resources/data/minecraft/recipes/dark_oak_boat.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:dark_oak_planks"
+      "tag": "quark:dark_oak_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/dark_oak_button.json
+++ b/src/main/resources/data/minecraft/recipes/dark_oak_button.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "group": "wooden_button",
+  "ingredients": [
+    {
+      "item": "minecraft:dark_oak_planks"
+    }
+  ],
+  "result": {
+    "item": "minecraft:dark_oak_button"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/dark_oak_button.json
+++ b/src/main/resources/data/minecraft/recipes/dark_oak_button.json
@@ -3,7 +3,7 @@
   "group": "wooden_button",
   "ingredients": [
     {
-      "item": "minecraft:dark_oak_planks"
+      "tag": "quark:dark_oak_planks"
     }
   ],
   "result": {

--- a/src/main/resources/data/minecraft/recipes/dark_oak_door.json
+++ b/src/main/resources/data/minecraft/recipes/dark_oak_door.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_door",
+  "pattern": [
+    "##",
+    "##",
+    "##"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:dark_oak_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:dark_oak_door",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/dark_oak_door.json
+++ b/src/main/resources/data/minecraft/recipes/dark_oak_door.json
@@ -8,7 +8,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:dark_oak_planks"
+      "tag": "quark:dark_oak_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/dark_oak_fence.json
+++ b/src/main/resources/data/minecraft/recipes/dark_oak_fence.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_fence",
+  "pattern": [
+    "W#W",
+    "W#W"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stick"
+    },
+    "W": {
+      "item": "minecraft:dark_oak_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:dark_oak_fence",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/dark_oak_fence.json
+++ b/src/main/resources/data/minecraft/recipes/dark_oak_fence.json
@@ -7,10 +7,10 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:stick"
+      "tag": "forge:rods/wooden"
     },
     "W": {
-      "item": "minecraft:dark_oak_planks"
+      "tag": "quark:dark_oak_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/dark_oak_fence_gate.json
+++ b/src/main/resources/data/minecraft/recipes/dark_oak_fence_gate.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_fence_gate",
+  "pattern": [
+    "#W#",
+    "#W#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stick"
+    },
+    "W": {
+      "item": "minecraft:dark_oak_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:dark_oak_fence_gate"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/dark_oak_fence_gate.json
+++ b/src/main/resources/data/minecraft/recipes/dark_oak_fence_gate.json
@@ -7,10 +7,10 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:stick"
+      "tag": "forge:rods/wooden"
     },
     "W": {
-      "item": "minecraft:dark_oak_planks"
+      "tag": "quark:dark_oak_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/dark_oak_pressure_plate.json
+++ b/src/main/resources/data/minecraft/recipes/dark_oak_pressure_plate.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_pressure_plate",
+  "pattern": [
+    "##"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:dark_oak_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:dark_oak_pressure_plate"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/dark_oak_pressure_plate.json
+++ b/src/main/resources/data/minecraft/recipes/dark_oak_pressure_plate.json
@@ -6,7 +6,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:dark_oak_planks"
+      "tag": "quark:dark_oak_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/dark_oak_sign.json
+++ b/src/main/resources/data/minecraft/recipes/dark_oak_sign.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "sign",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:dark_oak_planks"
+    },
+    "X": {
+      "item": "minecraft:stick"
+    }
+  },
+  "result": {
+    "item": "minecraft:dark_oak_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/dark_oak_sign.json
+++ b/src/main/resources/data/minecraft/recipes/dark_oak_sign.json
@@ -8,10 +8,10 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:dark_oak_planks"
+      "tag": "quark:dark_oak_planks"
     },
     "X": {
-      "item": "minecraft:stick"
+      "tag": "forge:rods/wooden"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/dark_oak_slab.json
+++ b/src/main/resources/data/minecraft/recipes/dark_oak_slab.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_slab",
+  "pattern": [
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:dark_oak_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:dark_oak_slab",
+    "count": 6
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/dark_oak_slab.json
+++ b/src/main/resources/data/minecraft/recipes/dark_oak_slab.json
@@ -6,7 +6,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:dark_oak_planks"
+      "tag": "quark:dark_oak_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/dark_oak_stairs.json
+++ b/src/main/resources/data/minecraft/recipes/dark_oak_stairs.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_stairs",
+  "pattern": [
+    "#  ",
+    "## ",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:dark_oak_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:dark_oak_stairs",
+    "count": 4
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/dark_oak_stairs.json
+++ b/src/main/resources/data/minecraft/recipes/dark_oak_stairs.json
@@ -8,7 +8,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:dark_oak_planks"
+      "tag": "quark:dark_oak_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/dark_oak_trapdoor.json
+++ b/src/main/resources/data/minecraft/recipes/dark_oak_trapdoor.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_trapdoor",
+  "pattern": [
+    "###",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:dark_oak_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:dark_oak_trapdoor",
+    "count": 2
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/dark_oak_trapdoor.json
+++ b/src/main/resources/data/minecraft/recipes/dark_oak_trapdoor.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:dark_oak_planks"
+      "tag": "quark:dark_oak_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/jungle_boat.json
+++ b/src/main/resources/data/minecraft/recipes/jungle_boat.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "boat",
+  "pattern": [
+    "# #",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:jungle_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:jungle_boat"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/jungle_boat.json
+++ b/src/main/resources/data/minecraft/recipes/jungle_boat.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:jungle_planks"
+      "tag": "quark:jungle_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/jungle_button.json
+++ b/src/main/resources/data/minecraft/recipes/jungle_button.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "group": "wooden_button",
+  "ingredients": [
+    {
+      "item": "minecraft:jungle_planks"
+    }
+  ],
+  "result": {
+    "item": "minecraft:jungle_button"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/jungle_button.json
+++ b/src/main/resources/data/minecraft/recipes/jungle_button.json
@@ -3,7 +3,7 @@
   "group": "wooden_button",
   "ingredients": [
     {
-      "item": "minecraft:jungle_planks"
+      "tag": "quark:jungle_planks"
     }
   ],
   "result": {

--- a/src/main/resources/data/minecraft/recipes/jungle_door.json
+++ b/src/main/resources/data/minecraft/recipes/jungle_door.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_door",
+  "pattern": [
+    "##",
+    "##",
+    "##"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:jungle_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:jungle_door",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/jungle_door.json
+++ b/src/main/resources/data/minecraft/recipes/jungle_door.json
@@ -8,7 +8,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:jungle_planks"
+      "tag": "quark:jungle_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/jungle_fence.json
+++ b/src/main/resources/data/minecraft/recipes/jungle_fence.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_fence",
+  "pattern": [
+    "W#W",
+    "W#W"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stick"
+    },
+    "W": {
+      "item": "minecraft:jungle_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:jungle_fence",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/jungle_fence.json
+++ b/src/main/resources/data/minecraft/recipes/jungle_fence.json
@@ -7,10 +7,10 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:stick"
+      "tag": "forge:rods/wooden"
     },
     "W": {
-      "item": "minecraft:jungle_planks"
+      "tag": "quark:jungle_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/jungle_fence_gate.json
+++ b/src/main/resources/data/minecraft/recipes/jungle_fence_gate.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_fence_gate",
+  "pattern": [
+    "#W#",
+    "#W#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stick"
+    },
+    "W": {
+      "item": "minecraft:jungle_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:jungle_fence_gate"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/jungle_fence_gate.json
+++ b/src/main/resources/data/minecraft/recipes/jungle_fence_gate.json
@@ -7,10 +7,10 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:stick"
+      "tag": "forge:rods/wooden"
     },
     "W": {
-      "item": "minecraft:jungle_planks"
+      "tag": "quark:jungle_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/jungle_pressure_plate.json
+++ b/src/main/resources/data/minecraft/recipes/jungle_pressure_plate.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_pressure_plate",
+  "pattern": [
+    "##"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:jungle_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:jungle_pressure_plate"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/jungle_pressure_plate.json
+++ b/src/main/resources/data/minecraft/recipes/jungle_pressure_plate.json
@@ -6,7 +6,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:jungle_planks"
+      "tag": "quark:jungle_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/jungle_sign.json
+++ b/src/main/resources/data/minecraft/recipes/jungle_sign.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "sign",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:jungle_planks"
+    },
+    "X": {
+      "item": "minecraft:stick"
+    }
+  },
+  "result": {
+    "item": "minecraft:jungle_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/jungle_sign.json
+++ b/src/main/resources/data/minecraft/recipes/jungle_sign.json
@@ -8,10 +8,10 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:jungle_planks"
+      "tag": "quark:jungle_planks"
     },
     "X": {
-      "item": "minecraft:stick"
+      "tag": "forge:rods/wooden"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/jungle_slab.json
+++ b/src/main/resources/data/minecraft/recipes/jungle_slab.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_slab",
+  "pattern": [
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:jungle_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:jungle_slab",
+    "count": 6
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/jungle_slab.json
+++ b/src/main/resources/data/minecraft/recipes/jungle_slab.json
@@ -6,7 +6,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:jungle_planks"
+      "tag": "quark:jungle_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/jungle_stairs.json
+++ b/src/main/resources/data/minecraft/recipes/jungle_stairs.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_stairs",
+  "pattern": [
+    "#  ",
+    "## ",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:jungle_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:jungle_stairs",
+    "count": 4
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/jungle_stairs.json
+++ b/src/main/resources/data/minecraft/recipes/jungle_stairs.json
@@ -8,7 +8,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:jungle_planks"
+      "tag": "quark:jungle_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/jungle_trapdoor.json
+++ b/src/main/resources/data/minecraft/recipes/jungle_trapdoor.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_trapdoor",
+  "pattern": [
+    "###",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:jungle_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:jungle_trapdoor",
+    "count": 2
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/jungle_trapdoor.json
+++ b/src/main/resources/data/minecraft/recipes/jungle_trapdoor.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:jungle_planks"
+      "tag": "quark:jungle_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/oak_boat.json
+++ b/src/main/resources/data/minecraft/recipes/oak_boat.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "boat",
+  "pattern": [
+    "# #",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:oak_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:oak_boat"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/oak_boat.json
+++ b/src/main/resources/data/minecraft/recipes/oak_boat.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:oak_planks"
+      "tag": "quark:oak_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/oak_button.json
+++ b/src/main/resources/data/minecraft/recipes/oak_button.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "group": "wooden_button",
+  "ingredients": [
+    {
+      "item": "minecraft:oak_planks"
+    }
+  ],
+  "result": {
+    "item": "minecraft:oak_button"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/oak_button.json
+++ b/src/main/resources/data/minecraft/recipes/oak_button.json
@@ -3,7 +3,7 @@
   "group": "wooden_button",
   "ingredients": [
     {
-      "item": "minecraft:oak_planks"
+      "tag": "quark:oak_planks"
     }
   ],
   "result": {

--- a/src/main/resources/data/minecraft/recipes/oak_door.json
+++ b/src/main/resources/data/minecraft/recipes/oak_door.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_door",
+  "pattern": [
+    "##",
+    "##",
+    "##"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:oak_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:oak_door",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/oak_door.json
+++ b/src/main/resources/data/minecraft/recipes/oak_door.json
@@ -8,7 +8,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:oak_planks"
+      "tag": "quark:oak_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/oak_fence.json
+++ b/src/main/resources/data/minecraft/recipes/oak_fence.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_fence",
+  "pattern": [
+    "W#W",
+    "W#W"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stick"
+    },
+    "W": {
+      "item": "minecraft:oak_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:oak_fence",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/oak_fence.json
+++ b/src/main/resources/data/minecraft/recipes/oak_fence.json
@@ -7,10 +7,10 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:stick"
+      "tag": "forge:rods/wooden"
     },
     "W": {
-      "item": "minecraft:oak_planks"
+      "tag": "quark:oak_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/oak_fence_gate.json
+++ b/src/main/resources/data/minecraft/recipes/oak_fence_gate.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_fence_gate",
+  "pattern": [
+    "#W#",
+    "#W#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stick"
+    },
+    "W": {
+      "item": "minecraft:oak_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:oak_fence_gate"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/oak_fence_gate.json
+++ b/src/main/resources/data/minecraft/recipes/oak_fence_gate.json
@@ -7,10 +7,10 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:stick"
+      "tag": "forge:rods/wooden"
     },
     "W": {
-      "item": "minecraft:oak_planks"
+      "tag": "quark:oak_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/oak_pressure_plate.json
+++ b/src/main/resources/data/minecraft/recipes/oak_pressure_plate.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_pressure_plate",
+  "pattern": [
+    "##"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:oak_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:oak_pressure_plate"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/oak_pressure_plate.json
+++ b/src/main/resources/data/minecraft/recipes/oak_pressure_plate.json
@@ -6,7 +6,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:oak_planks"
+      "tag": "quark:oak_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/oak_sign.json
+++ b/src/main/resources/data/minecraft/recipes/oak_sign.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "sign",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:oak_planks"
+    },
+    "X": {
+      "item": "minecraft:stick"
+    }
+  },
+  "result": {
+    "item": "minecraft:oak_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/oak_sign.json
+++ b/src/main/resources/data/minecraft/recipes/oak_sign.json
@@ -8,10 +8,10 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:oak_planks"
+      "tag": "quark:oak_planks"
     },
     "X": {
-      "item": "minecraft:stick"
+      "tag": "forge:rods/wooden"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/oak_slab.json
+++ b/src/main/resources/data/minecraft/recipes/oak_slab.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_slab",
+  "pattern": [
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:oak_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:oak_slab",
+    "count": 6
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/oak_slab.json
+++ b/src/main/resources/data/minecraft/recipes/oak_slab.json
@@ -6,7 +6,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:oak_planks"
+      "tag": "quark:oak_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/oak_stairs.json
+++ b/src/main/resources/data/minecraft/recipes/oak_stairs.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_stairs",
+  "pattern": [
+    "#  ",
+    "## ",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:oak_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:oak_stairs",
+    "count": 4
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/oak_stairs.json
+++ b/src/main/resources/data/minecraft/recipes/oak_stairs.json
@@ -8,7 +8,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:oak_planks"
+      "tag": "quark:oak_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/oak_trapdoor.json
+++ b/src/main/resources/data/minecraft/recipes/oak_trapdoor.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_trapdoor",
+  "pattern": [
+    "###",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:oak_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:oak_trapdoor",
+    "count": 2
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/oak_trapdoor.json
+++ b/src/main/resources/data/minecraft/recipes/oak_trapdoor.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:oak_planks"
+      "tag": "quark:oak_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/spruce_boat.json
+++ b/src/main/resources/data/minecraft/recipes/spruce_boat.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "boat",
+  "pattern": [
+    "# #",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:spruce_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:spruce_boat"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/spruce_boat.json
+++ b/src/main/resources/data/minecraft/recipes/spruce_boat.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:spruce_planks"
+      "tag": "quark:spruce_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/spruce_button.json
+++ b/src/main/resources/data/minecraft/recipes/spruce_button.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "group": "wooden_button",
+  "ingredients": [
+    {
+      "item": "minecraft:spruce_planks"
+    }
+  ],
+  "result": {
+    "item": "minecraft:spruce_button"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/spruce_button.json
+++ b/src/main/resources/data/minecraft/recipes/spruce_button.json
@@ -3,7 +3,7 @@
   "group": "wooden_button",
   "ingredients": [
     {
-      "item": "minecraft:spruce_planks"
+      "tag": "quark:spruce_planks"
     }
   ],
   "result": {

--- a/src/main/resources/data/minecraft/recipes/spruce_door.json
+++ b/src/main/resources/data/minecraft/recipes/spruce_door.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_door",
+  "pattern": [
+    "##",
+    "##",
+    "##"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:spruce_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:spruce_door",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/spruce_door.json
+++ b/src/main/resources/data/minecraft/recipes/spruce_door.json
@@ -8,7 +8,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:spruce_planks"
+      "tag": "quark:spruce_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/spruce_fence.json
+++ b/src/main/resources/data/minecraft/recipes/spruce_fence.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_fence",
+  "pattern": [
+    "W#W",
+    "W#W"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stick"
+    },
+    "W": {
+      "item": "minecraft:spruce_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:spruce_fence",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/spruce_fence.json
+++ b/src/main/resources/data/minecraft/recipes/spruce_fence.json
@@ -7,10 +7,10 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:stick"
+      "tag": "forge:rods/wooden"
     },
     "W": {
-      "item": "minecraft:spruce_planks"
+      "tag": "quark:spruce_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/spruce_fence_gate.json
+++ b/src/main/resources/data/minecraft/recipes/spruce_fence_gate.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_fence_gate",
+  "pattern": [
+    "#W#",
+    "#W#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stick"
+    },
+    "W": {
+      "item": "minecraft:spruce_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:spruce_fence_gate"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/spruce_fence_gate.json
+++ b/src/main/resources/data/minecraft/recipes/spruce_fence_gate.json
@@ -7,10 +7,10 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:stick"
+      "tag": "forge:rods/wooden"
     },
     "W": {
-      "item": "minecraft:spruce_planks"
+      "tag": "quark:spruce_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/spruce_pressure_plate.json
+++ b/src/main/resources/data/minecraft/recipes/spruce_pressure_plate.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_pressure_plate",
+  "pattern": [
+    "##"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:spruce_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:spruce_pressure_plate"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/spruce_pressure_plate.json
+++ b/src/main/resources/data/minecraft/recipes/spruce_pressure_plate.json
@@ -6,7 +6,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:spruce_planks"
+      "tag": "quark:spruce_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/spruce_sign.json
+++ b/src/main/resources/data/minecraft/recipes/spruce_sign.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "sign",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:spruce_planks"
+    },
+    "X": {
+      "item": "minecraft:stick"
+    }
+  },
+  "result": {
+    "item": "minecraft:spruce_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/spruce_sign.json
+++ b/src/main/resources/data/minecraft/recipes/spruce_sign.json
@@ -8,10 +8,10 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:spruce_planks"
+      "tag": "quark:spruce_planks"
     },
     "X": {
-      "item": "minecraft:stick"
+      "tag": "forge:rods/wooden"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/spruce_slab.json
+++ b/src/main/resources/data/minecraft/recipes/spruce_slab.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_slab",
+  "pattern": [
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:spruce_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:spruce_slab",
+    "count": 6
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/spruce_slab.json
+++ b/src/main/resources/data/minecraft/recipes/spruce_slab.json
@@ -6,7 +6,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:spruce_planks"
+      "tag": "quark:spruce_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/spruce_stairs.json
+++ b/src/main/resources/data/minecraft/recipes/spruce_stairs.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_stairs",
+  "pattern": [
+    "#  ",
+    "## ",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:spruce_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:spruce_stairs",
+    "count": 4
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/spruce_stairs.json
+++ b/src/main/resources/data/minecraft/recipes/spruce_stairs.json
@@ -8,7 +8,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:spruce_planks"
+      "tag": "quark:spruce_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/spruce_trapdoor.json
+++ b/src/main/resources/data/minecraft/recipes/spruce_trapdoor.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_trapdoor",
+  "pattern": [
+    "###",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:spruce_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:spruce_trapdoor",
+    "count": 2
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/spruce_trapdoor.json
+++ b/src/main/resources/data/minecraft/recipes/spruce_trapdoor.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:spruce_planks"
+      "tag": "quark:spruce_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/warped_button.json
+++ b/src/main/resources/data/minecraft/recipes/warped_button.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "group": "wooden_button",
+  "ingredients": [
+    {
+      "item": "minecraft:warped_planks"
+    }
+  ],
+  "result": {
+    "item": "minecraft:warped_button"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/warped_button.json
+++ b/src/main/resources/data/minecraft/recipes/warped_button.json
@@ -3,7 +3,7 @@
   "group": "wooden_button",
   "ingredients": [
     {
-      "item": "minecraft:warped_planks"
+      "tag": "quark:warped_planks"
     }
   ],
   "result": {

--- a/src/main/resources/data/minecraft/recipes/warped_door.json
+++ b/src/main/resources/data/minecraft/recipes/warped_door.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_door",
+  "pattern": [
+    "##",
+    "##",
+    "##"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:warped_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:warped_door",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/warped_door.json
+++ b/src/main/resources/data/minecraft/recipes/warped_door.json
@@ -8,7 +8,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:warped_planks"
+      "tag": "quark:warped_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/warped_fence.json
+++ b/src/main/resources/data/minecraft/recipes/warped_fence.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_fence",
+  "pattern": [
+    "W#W",
+    "W#W"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stick"
+    },
+    "W": {
+      "item": "minecraft:warped_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:warped_fence",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/warped_fence.json
+++ b/src/main/resources/data/minecraft/recipes/warped_fence.json
@@ -7,10 +7,10 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:stick"
+      "tag": "forge:rods/wooden"
     },
     "W": {
-      "item": "minecraft:warped_planks"
+      "tag": "quark:warped_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/warped_fence_gate.json
+++ b/src/main/resources/data/minecraft/recipes/warped_fence_gate.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_fence_gate",
+  "pattern": [
+    "#W#",
+    "#W#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stick"
+    },
+    "W": {
+      "item": "minecraft:warped_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:warped_fence_gate"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/warped_fence_gate.json
+++ b/src/main/resources/data/minecraft/recipes/warped_fence_gate.json
@@ -7,10 +7,10 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:stick"
+      "tag": "forge:rods/wooden"
     },
     "W": {
-      "item": "minecraft:warped_planks"
+      "tag": "quark:warped_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/warped_pressure_plate.json
+++ b/src/main/resources/data/minecraft/recipes/warped_pressure_plate.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_pressure_plate",
+  "pattern": [
+    "##"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:warped_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:warped_pressure_plate"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/warped_pressure_plate.json
+++ b/src/main/resources/data/minecraft/recipes/warped_pressure_plate.json
@@ -6,7 +6,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:warped_planks"
+      "tag": "quark:warped_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/warped_sign.json
+++ b/src/main/resources/data/minecraft/recipes/warped_sign.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "sign",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:warped_planks"
+    },
+    "X": {
+      "item": "minecraft:stick"
+    }
+  },
+  "result": {
+    "item": "minecraft:warped_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/warped_sign.json
+++ b/src/main/resources/data/minecraft/recipes/warped_sign.json
@@ -8,10 +8,10 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:warped_planks"
+      "tag": "quark:warped_planks"
     },
     "X": {
-      "item": "minecraft:stick"
+      "tag": "forge:rods/wooden"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/warped_slab.json
+++ b/src/main/resources/data/minecraft/recipes/warped_slab.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_slab",
+  "pattern": [
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:warped_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:warped_slab",
+    "count": 6
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/warped_slab.json
+++ b/src/main/resources/data/minecraft/recipes/warped_slab.json
@@ -6,7 +6,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:warped_planks"
+      "tag": "quark:warped_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/warped_stairs.json
+++ b/src/main/resources/data/minecraft/recipes/warped_stairs.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_stairs",
+  "pattern": [
+    "#  ",
+    "## ",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:warped_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:warped_stairs",
+    "count": 4
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/warped_stairs.json
+++ b/src/main/resources/data/minecraft/recipes/warped_stairs.json
@@ -8,7 +8,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:warped_planks"
+      "tag": "quark:warped_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/minecraft/recipes/warped_trapdoor.json
+++ b/src/main/resources/data/minecraft/recipes/warped_trapdoor.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "wooden_trapdoor",
+  "pattern": [
+    "###",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:warped_planks"
+    }
+  },
+  "result": {
+    "item": "minecraft:warped_trapdoor",
+    "count": 2
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/warped_trapdoor.json
+++ b/src/main/resources/data/minecraft/recipes/warped_trapdoor.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:warped_planks"
+      "tag": "quark:warped_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/quark/recipes/building/crafting/acacia_bookshelf.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/acacia_bookshelf.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:acacia_planks"
+      "tag": "quark:acacia_planks"
     },
     "X": {
       "item": "minecraft:book"

--- a/src/main/resources/data/quark/recipes/building/crafting/acacia_ladder.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/acacia_ladder.json
@@ -10,7 +10,7 @@
       "tag": "forge:rods/wooden"
     },
     "W": {
-      "item": "minecraft:acacia_planks"
+      "tag": "quark:acacia_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/quark/recipes/building/crafting/birch_bookshelf.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/birch_bookshelf.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:birch_planks"
+      "tag": "quark:birch_planks"
     },
     "X": {
       "item": "minecraft:book"

--- a/src/main/resources/data/quark/recipes/building/crafting/birch_ladder.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/birch_ladder.json
@@ -10,7 +10,7 @@
       "tag": "forge:rods/wooden"
     },
     "W": {
-      "item": "minecraft:birch_planks"
+      "tag": "quark:birch_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/quark/recipes/building/crafting/chests/acacia_chest.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/chests/acacia_chest.json
@@ -8,7 +8,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:acacia_planks"
+      "tag": "quark:acacia_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/quark/recipes/building/crafting/chests/birch_chest.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/chests/birch_chest.json
@@ -8,7 +8,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:birch_planks"
+      "tag": "quark:birch_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/quark/recipes/building/crafting/chests/crimson_chest.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/chests/crimson_chest.json
@@ -8,7 +8,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:crimson_planks"
+      "tag": "quark:crimson_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/quark/recipes/building/crafting/chests/dark_oak_chest.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/chests/dark_oak_chest.json
@@ -8,7 +8,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:dark_oak_planks"
+      "tag": "quark:dark_oak_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/quark/recipes/building/crafting/chests/jungle_chest.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/chests/jungle_chest.json
@@ -8,7 +8,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:jungle_planks"
+      "tag": "quark:jungle_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/quark/recipes/building/crafting/chests/oak_chest.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/chests/oak_chest.json
@@ -8,7 +8,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:oak_planks"
+      "tag": "quark:oak_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/quark/recipes/building/crafting/chests/spruce_chest.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/chests/spruce_chest.json
@@ -8,7 +8,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:spruce_planks"
+      "tag": "quark:spruce_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/quark/recipes/building/crafting/chests/warped_chest.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/chests/warped_chest.json
@@ -8,7 +8,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:warped_planks"
+      "tag": "quark:warped_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/quark/recipes/building/crafting/crimson_bookshelf.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/crimson_bookshelf.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:crimson_planks"
+      "tag": "quark:crimson_planks"
     },
     "X": {
       "item": "minecraft:book"

--- a/src/main/resources/data/quark/recipes/building/crafting/crimson_ladder.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/crimson_ladder.json
@@ -10,7 +10,7 @@
       "tag": "forge:rods/wooden"
     },
     "W": {
-      "item": "minecraft:crimson_planks"
+      "tag": "quark:crimson_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/quark/recipes/building/crafting/dark_oak_bookshelf.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/dark_oak_bookshelf.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:dark_oak_planks"
+      "tag": "quark:dark_oak_planks"
     },
     "X": {
       "item": "minecraft:book"

--- a/src/main/resources/data/quark/recipes/building/crafting/dark_oak_ladder.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/dark_oak_ladder.json
@@ -10,7 +10,7 @@
       "tag": "forge:rods/wooden"
     },
     "W": {
-      "item": "minecraft:dark_oak_planks"
+      "tag": "quark:dark_oak_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/quark/recipes/building/crafting/jungle_bookshelf.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/jungle_bookshelf.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:jungle_planks"
+      "tag": "quark:jungle_planks"
     },
     "X": {
       "item": "minecraft:book"

--- a/src/main/resources/data/quark/recipes/building/crafting/jungle_ladder.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/jungle_ladder.json
@@ -10,7 +10,7 @@
       "tag": "forge:rods/wooden"
     },
     "W": {
-      "item": "minecraft:jungle_planks"
+      "tag": "quark:jungle_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/quark/recipes/building/crafting/oak_bookshelf.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/oak_bookshelf.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:oak_planks"
+      "tag": "quark:oak_planks"
     },
     "X": {
       "item": "minecraft:book"

--- a/src/main/resources/data/quark/recipes/building/crafting/oak_ladder.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/oak_ladder.json
@@ -10,7 +10,7 @@
       "tag": "forge:rods/wooden"
     },
     "W": {
-      "item": "minecraft:oak_planks"
+      "tag": "quark:oak_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/quark/recipes/building/crafting/spruce_bookshelf.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/spruce_bookshelf.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:spruce_planks"
+      "tag": "quark:spruce_planks"
     },
     "X": {
       "item": "minecraft:book"

--- a/src/main/resources/data/quark/recipes/building/crafting/spruce_ladder.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/spruce_ladder.json
@@ -10,7 +10,7 @@
       "tag": "forge:rods/wooden"
     },
     "W": {
-      "item": "minecraft:spruce_planks"
+      "tag": "quark:spruce_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_acacia_planks_revert.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_acacia_planks_revert.json
@@ -1,18 +1,23 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "ingredients": [
-    {
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
       "item": "quark:vertical_acacia_planks"
     }
-  ],
+  },
   "result": {
     "item": "minecraft:acacia_planks",
-    "count": 1
+    "count": 3
   },
   "conditions": [
     {
       "type": "quark:flag",
-        "flag": "vertical_planks"
+      "flag": "vertical_planks"
     }
   ]
 } 

--- a/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_birch_planks_revert.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_birch_planks_revert.json
@@ -1,18 +1,23 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "ingredients": [
-    {
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
       "item": "quark:vertical_birch_planks"
     }
-  ],
+  },
   "result": {
     "item": "minecraft:birch_planks",
-    "count": 1
+    "count": 3
   },
   "conditions": [
     {
       "type": "quark:flag",
-        "flag": "vertical_planks"
+      "flag": "vertical_planks"
     }
   ]
 } 

--- a/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_black_stained_planks_revert.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_black_stained_planks_revert.json
@@ -1,13 +1,18 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "ingredients": [
-    {
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
       "item": "quark:vertical_black_stained_planks"
     }
-  ],
+  },
   "result": {
     "item": "quark:black_stained_planks",
-    "count": 1
+    "count": 3
   },
   "conditions": [
     {

--- a/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_blue_stained_planks_revert.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_blue_stained_planks_revert.json
@@ -1,13 +1,18 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "ingredients": [
-    {
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
       "item": "quark:vertical_blue_stained_planks"
     }
-  ],
+  },
   "result": {
     "item": "quark:blue_stained_planks",
-    "count": 1
+    "count": 3
   },
   "conditions": [
     {

--- a/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_brown_stained_planks_revert.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_brown_stained_planks_revert.json
@@ -1,13 +1,18 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "ingredients": [
-    {
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
       "item": "quark:vertical_brown_stained_planks"
     }
-  ],
+  },
   "result": {
     "item": "quark:brown_stained_planks",
-    "count": 1
+    "count": 3
   },
   "conditions": [
     {

--- a/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_crimson_planks_revert.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_crimson_planks_revert.json
@@ -1,18 +1,23 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "ingredients": [
-    {
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
       "item": "quark:vertical_crimson_planks"
     }
-  ],
+  },
   "result": {
     "item": "minecraft:crimson_planks",
-    "count": 1
+    "count": 3
   },
   "conditions": [
     {
       "type": "quark:flag",
-        "flag": "vertical_planks"
+      "flag": "vertical_planks"
     }
   ]
 } 

--- a/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_cyan_stained_planks_revert.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_cyan_stained_planks_revert.json
@@ -1,13 +1,18 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "ingredients": [
-    {
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
       "item": "quark:vertical_cyan_stained_planks"
     }
-  ],
+  },
   "result": {
     "item": "quark:cyan_stained_planks",
-    "count": 1
+    "count": 3
   },
   "conditions": [
     {

--- a/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_dark_oak_planks_revert.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_dark_oak_planks_revert.json
@@ -1,18 +1,23 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "ingredients": [
-    {
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
       "item": "quark:vertical_dark_oak_planks"
     }
-  ],
+  },
   "result": {
     "item": "minecraft:dark_oak_planks",
-    "count": 1
+    "count": 3
   },
   "conditions": [
     {
       "type": "quark:flag",
-        "flag": "vertical_planks"
+      "flag": "vertical_planks"
     }
   ]
 } 

--- a/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_gray_stained_planks_revert.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_gray_stained_planks_revert.json
@@ -1,13 +1,18 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "ingredients": [
-    {
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
       "item": "quark:vertical_gray_stained_planks"
     }
-  ],
+  },
   "result": {
     "item": "quark:gray_stained_planks",
-    "count": 1
+    "count": 3
   },
   "conditions": [
     {

--- a/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_green_stained_planks_revert.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_green_stained_planks_revert.json
@@ -1,13 +1,18 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "ingredients": [
-    {
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
       "item": "quark:vertical_green_stained_planks"
     }
-  ],
+  },
   "result": {
     "item": "quark:green_stained_planks",
-    "count": 1
+    "count": 3
   },
   "conditions": [
     {

--- a/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_jungle_planks_revert.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_jungle_planks_revert.json
@@ -1,18 +1,23 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "ingredients": [
-    {
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
       "item": "quark:vertical_jungle_planks"
     }
-  ],
+  },
   "result": {
     "item": "minecraft:jungle_planks",
-    "count": 1
+    "count": 3
   },
   "conditions": [
     {
       "type": "quark:flag",
-        "flag": "vertical_planks"
+      "flag": "vertical_planks"
     }
   ]
 } 

--- a/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_light_blue_stained_planks_revert.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_light_blue_stained_planks_revert.json
@@ -1,13 +1,18 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "ingredients": [
-    {
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
       "item": "quark:vertical_light_blue_stained_planks"
     }
-  ],
+  },
   "result": {
     "item": "quark:light_blue_stained_planks",
-    "count": 1
+    "count": 3
   },
   "conditions": [
     {

--- a/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_light_gray_stained_planks_revert.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_light_gray_stained_planks_revert.json
@@ -1,13 +1,18 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "ingredients": [
-    {
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
       "item": "quark:vertical_light_gray_stained_planks"
     }
-  ],
+  },
   "result": {
     "item": "quark:light_gray_stained_planks",
-    "count": 1
+    "count": 3
   },
   "conditions": [
     {

--- a/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_lime_stained_planks_revert.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_lime_stained_planks_revert.json
@@ -1,13 +1,18 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "ingredients": [
-    {
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
       "item": "quark:vertical_lime_stained_planks"
     }
-  ],
+  },
   "result": {
     "item": "quark:lime_stained_planks",
-    "count": 1
+    "count": 3
   },
   "conditions": [
     {

--- a/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_magenta_stained_planks_revert.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_magenta_stained_planks_revert.json
@@ -1,13 +1,18 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "ingredients": [
-    {
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
       "item": "quark:vertical_magenta_stained_planks"
     }
-  ],
+  },
   "result": {
     "item": "quark:magenta_stained_planks",
-    "count": 1
+    "count": 3
   },
   "conditions": [
     {

--- a/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_oak_planks_revert.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_oak_planks_revert.json
@@ -1,18 +1,23 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "ingredients": [
-    {
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
       "item": "quark:vertical_oak_planks"
     }
-  ],
+  },
   "result": {
     "item": "minecraft:oak_planks",
-    "count": 1
+    "count": 3
   },
   "conditions": [
     {
       "type": "quark:flag",
-        "flag": "vertical_planks"
+      "flag": "vertical_planks"
     }
   ]
 } 

--- a/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_orange_stained_planks_revert.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_orange_stained_planks_revert.json
@@ -1,13 +1,18 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "ingredients": [
-    {
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
       "item": "quark:vertical_orange_stained_planks"
     }
-  ],
+  },
   "result": {
     "item": "quark:orange_stained_planks",
-    "count": 1
+    "count": 3
   },
   "conditions": [
     {

--- a/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_pink_stained_planks_revert.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_pink_stained_planks_revert.json
@@ -1,13 +1,18 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "ingredients": [
-    {
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
       "item": "quark:vertical_pink_stained_planks"
     }
-  ],
+  },
   "result": {
     "item": "quark:pink_stained_planks",
-    "count": 1
+    "count": 3
   },
   "conditions": [
     {

--- a/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_purple_stained_planks_revert.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_purple_stained_planks_revert.json
@@ -1,13 +1,18 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "ingredients": [
-    {
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
       "item": "quark:vertical_purple_stained_planks"
     }
-  ],
+  },
   "result": {
     "item": "quark:purple_stained_planks",
-    "count": 1
+    "count": 3
   },
   "conditions": [
     {

--- a/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_red_stained_planks_revert.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_red_stained_planks_revert.json
@@ -1,13 +1,18 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "ingredients": [
-    {
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
       "item": "quark:vertical_red_stained_planks"
     }
-  ],
+  },
   "result": {
     "item": "quark:red_stained_planks",
-    "count": 1
+    "count": 3
   },
   "conditions": [
     {

--- a/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_spruce_planks_revert.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_spruce_planks_revert.json
@@ -1,18 +1,23 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "ingredients": [
-    {
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
       "item": "quark:vertical_spruce_planks"
     }
-  ],
+  },
   "result": {
     "item": "minecraft:spruce_planks",
-    "count": 1
+    "count": 3
   },
   "conditions": [
     {
       "type": "quark:flag",
-        "flag": "vertical_planks"
+      "flag": "vertical_planks"
     }
   ]
 } 

--- a/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_warped_planks_revert.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_warped_planks_revert.json
@@ -1,18 +1,23 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "ingredients": [
-    {
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
       "item": "quark:vertical_warped_planks"
     }
-  ],
+  },
   "result": {
     "item": "minecraft:warped_planks",
-    "count": 1
+    "count": 3
   },
   "conditions": [
     {
       "type": "quark:flag",
-        "flag": "vertical_planks"
+      "flag": "vertical_planks"
     }
   ]
 } 

--- a/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_white_stained_planks_revert.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_white_stained_planks_revert.json
@@ -1,13 +1,18 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "ingredients": [
-    {
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
       "item": "quark:vertical_white_stained_planks"
     }
-  ],
+  },
   "result": {
     "item": "quark:white_stained_planks",
-    "count": 1
+    "count": 3
   },
   "conditions": [
     {

--- a/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_yellow_stained_planks_revert.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/vertplanks/vertical_yellow_stained_planks_revert.json
@@ -1,13 +1,18 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "ingredients": [
-    {
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
       "item": "quark:vertical_yellow_stained_planks"
     }
-  ],
+  },
   "result": {
     "item": "quark:yellow_stained_planks",
-    "count": 1
+    "count": 3
   },
   "conditions": [
     {

--- a/src/main/resources/data/quark/recipes/building/crafting/warped_bookshelf.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/warped_bookshelf.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:warped_planks"
+      "tag": "quark:warped_planks"
     },
     "X": {
       "item": "minecraft:book"

--- a/src/main/resources/data/quark/recipes/building/crafting/warped_ladder.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/warped_ladder.json
@@ -10,7 +10,7 @@
       "tag": "forge:rods/wooden"
     },
     "W": {
-      "item": "minecraft:warped_planks"
+      "tag": "quark:warped_planks"
     }
   },
   "result": {

--- a/src/main/resources/data/quark/tags/items/acacia_planks.json
+++ b/src/main/resources/data/quark/tags/items/acacia_planks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:acacia_planks",
+	"quark:vertical_acacia_planks"
+  ]
+}

--- a/src/main/resources/data/quark/tags/items/birch_planks.json
+++ b/src/main/resources/data/quark/tags/items/birch_planks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:birch_planks",
+	"quark:vertical_birch_planks"
+  ]
+}

--- a/src/main/resources/data/quark/tags/items/crimson_planks.json
+++ b/src/main/resources/data/quark/tags/items/crimson_planks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:crimson_planks",
+	"quark:vertical_crimson_planks"
+  ]
+}

--- a/src/main/resources/data/quark/tags/items/dark_oak_planks.json
+++ b/src/main/resources/data/quark/tags/items/dark_oak_planks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:dark_oak_planks",
+	"quark:vertical_dark_oak_planks"
+  ]
+}

--- a/src/main/resources/data/quark/tags/items/jungle_planks.json
+++ b/src/main/resources/data/quark/tags/items/jungle_planks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:jungle_planks",
+	"quark:vertical_jungle_planks"
+  ]
+}

--- a/src/main/resources/data/quark/tags/items/oak_planks.json
+++ b/src/main/resources/data/quark/tags/items/oak_planks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:oak_planks",
+	"quark:vertical_oak_planks"
+  ]
+}

--- a/src/main/resources/data/quark/tags/items/spruce_planks.json
+++ b/src/main/resources/data/quark/tags/items/spruce_planks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:spruce_planks",
+	"quark:vertical_spruce_planks"
+  ]
+}

--- a/src/main/resources/data/quark/tags/items/warped_planks.json
+++ b/src/main/resources/data/quark/tags/items/warped_planks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:warped_planks",
+	"quark:vertical_warped_planks"
+  ]
+}


### PR DESCRIPTION
Closes #1982. Adds new item tags consisting of each plank and their corresponding vertical plank type (e.g. `#quark:acacia_planks` contains acacia planks and vertical acacia planks). All wood-type specific recipes, such as chests, buttons, and fences, are changed to use these tags whether vertical planks are enabled or not, which should not be a problem because vertical planks are uncraftable when not enabled. Additionally, these tags should be useful for other mods such as Buzzier Bees, which adds different beehives for each wood type.

In order to get the button recipe to work, the recipe for crafting vertical planks back to regular planks was changed to be the same shape as the recipe for crafting planks to vertical planks, which I don't think should be a problem because that's currently what the wiki says the reversion recipe is anyway.