### PR TITLE
Fix #2243

### DIFF
--- a/src/main/resources/data/minecraft/recipes/chest_minecart.json
+++ b/src/main/resources/data/minecraft/recipes/chest_minecart.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "A": {
-      "item": "minecraft:chest"
+      "tag": "forge:chests/wooden"
     },
     "B": {
       "item": "minecraft:minecart"


### PR DESCRIPTION
Closes #2243. Not entirely sure why Quark has duplicates of vanilla recipes, but the chest minecart one is now correctly the Forge version instead.