### PR TITLE
Add quark ladders to #minecraft:climbable tag

### DIFF
--- a/src/main/resources/data/minecraft/tags/blocks/climbable.json
+++ b/src/main/resources/data/minecraft/tags/blocks/climbable.json
@@ -1,0 +1,13 @@
+{
+  "replace": false,
+  "values": [
+	"quark:acacia_ladder",
+	"quark:birch_ladder",
+	"quark:dark_oak_ladder",
+	"quark:jungle_ladder",
+	"quark:spruce_ladder",
+	"quark:crimson_ladder",
+	"quark:warped_ladder",
+	"quark:iron_ladder"
+  ]
+}


### PR DESCRIPTION
Closes #2372. 1.16 introduced a new `#minecraft:climbable` tag that is used to recognize which blocks are climbable, and since Quark ladders were missing from the tag the game did not recognize the climbing action.

I also looked into the issue where iron ladders are making stone sounds. The custom sound type works perfectly, but it seems that the `METAL_` sound events are playing stone sounds instead. Could possibly be a Forge issue, but I don't know for sure.