### PR TITLE
Minor tweaks to JEI integration and elytra duping

### DIFF
--- a/src/main/java/vazkii/quark/integration/jei/ElytraDuplicationExtension.java
+++ b/src/main/java/vazkii/quark/integration/jei/ElytraDuplicationExtension.java
@@ -3,6 +3,7 @@ package vazkii.quark.integration.jei;
 import javax.annotation.Nullable;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
+import com.mojang.blaze3d.systems.RenderSystem;
 
 import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.ingredients.IIngredients;
@@ -28,6 +29,7 @@ public class ElytraDuplicationExtension implements ICraftingCategoryExtension {
 	@Override
 	public void drawInfo(int recipeWidth, int recipeHeight, MatrixStack matrixStack, double mouseX, double mouseY) {
 		Minecraft.getInstance().fontRenderer.drawString(matrixStack, I18n.format("quark.jei.makes_copy"), 60, 46, 0x555555);
+		RenderSystem.enableAlphaTest();
 	}
 
 	@Nullable

--- a/src/main/java/vazkii/quark/integration/jei/QuarkJeiPlugin.java
+++ b/src/main/java/vazkii/quark/integration/jei/QuarkJeiPlugin.java
@@ -24,6 +24,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.TranslationTextComponent;
 import vazkii.arl.util.ItemNBTHelper;
 import vazkii.quark.base.Quark;
 import vazkii.quark.base.module.ModuleLoader;
@@ -107,6 +108,7 @@ public class QuarkJeiPlugin implements IModPlugin {
 	// Runes only show up and can be only anvilled on enchanted items, so make some random enchanted items
 	private static ItemStack makeEnchantedDisplayItem(Item input, Random random) {
 		ItemStack stack = new ItemStack(input);
+		stack.setDisplayName(new TranslationTextComponent("quark.jei.any_enchanted"));
 		if (input.getItemEnchantability() <= 0) { // If it can't take anything in ench. tables...
 			stack.addEnchantment(Enchantments.UNBREAKING, 3); // it probably accepts unbreaking anyways
 			return stack;

--- a/src/main/java/vazkii/quark/tweaks/module/DragonScalesModule.java
+++ b/src/main/java/vazkii/quark/tweaks/module/DragonScalesModule.java
@@ -22,7 +22,7 @@ public class DragonScalesModule extends Module {
 	
 	@Override
 	public void construct() {
-		ForgeRegistries.RECIPE_SERIALIZERS.register(ElytraDuplicationRecipe.SERIALIZER);
+		ForgeRegistries.RECIPE_SERIALIZERS.register(ElytraDuplicationRecipe.SERIALIZER.setRegistryName("quark:elytra_duplication"));
 		
 		dragon_scale = new QuarkItem("dragon_scale", this, new Item.Properties().group(ItemGroup.MATERIALS));
 	}

--- a/src/main/java/vazkii/quark/tweaks/recipe/ElytraDuplicationRecipe.java
+++ b/src/main/java/vazkii/quark/tweaks/recipe/ElytraDuplicationRecipe.java
@@ -2,25 +2,26 @@ package vazkii.quark.tweaks.recipe;
 
 import javax.annotation.Nonnull;
 
-import com.google.gson.JsonObject;
-
 import net.minecraft.inventory.CraftingInventory;
 import net.minecraft.item.ElytraItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
-import net.minecraft.item.crafting.ICraftingRecipe;
 import net.minecraft.item.crafting.IRecipeSerializer;
 import net.minecraft.item.crafting.Ingredient;
-import net.minecraft.network.PacketBuffer;
+import net.minecraft.item.crafting.SpecialRecipe;
+import net.minecraft.item.crafting.SpecialRecipeSerializer;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
-import net.minecraftforge.registries.ForgeRegistryEntry;
 import vazkii.quark.tweaks.module.DragonScalesModule;
 
-public class ElytraDuplicationRecipe implements ICraftingRecipe {
+public class ElytraDuplicationRecipe extends SpecialRecipe {
 
-    public static final Serializer SERIALIZER = new Serializer();
+    public static final SpecialRecipeSerializer<?> SERIALIZER = new SpecialRecipeSerializer<>(ElytraDuplicationRecipe::new);
+
+	public ElytraDuplicationRecipe(ResourceLocation id) {
+		super(id);
+	}
 	
 	@Override
 	public boolean matches(@Nonnull CraftingInventory var1, @Nonnull World var2) {
@@ -93,39 +94,10 @@ public class ElytraDuplicationRecipe implements ICraftingRecipe {
 		list.set(1, Ingredient.fromStacks(new ItemStack(DragonScalesModule.dragon_scale)));
 		return list;
 	}
-	
-	
-	@Override
-	public ResourceLocation getId() {
-		return SERIALIZER.getRegistryName();
-	}
 
 	@Override
 	public IRecipeSerializer<?> getSerializer() {
 		return SERIALIZER;
 	}
-	
-    public static class Serializer extends ForgeRegistryEntry<IRecipeSerializer<?>> implements IRecipeSerializer<ElytraDuplicationRecipe> {
-
-        public Serializer() {
-            setRegistryName("quark:elytra_duplication");
-        }
-    	
-		@Override
-		public ElytraDuplicationRecipe read(ResourceLocation recipeId, JsonObject json) {
-			return new ElytraDuplicationRecipe();
-		}
-
-		@Override
-		public ElytraDuplicationRecipe read(ResourceLocation recipeId, PacketBuffer buffer) {
-			return new ElytraDuplicationRecipe();
-		}
-
-		@Override
-		public void write(PacketBuffer buffer, ElytraDuplicationRecipe recipe) {
-			// NO-OP
-		}
-    	
-    }
 
 }

--- a/src/main/resources/assets/quark/lang/en_us.json
+++ b/src/main/resources/assets/quark/lang/en_us.json
@@ -102,6 +102,7 @@
 	"quark.camera.greetings": "Greetings from %s!",
 
 	"quark.jei.makes_copy": "Makes Copy",
+	"quark.jei.any_enchanted": "Any Enchanted Item",
 	
 	"quark.keybind.change_hotbar": "Hotbar Swapper",
 	"quark.keybind.lock_rotation": "Rotation Lock",


### PR DESCRIPTION
* Fix broken transparency on shapeless icon for JEI elytra dupe so it doesn't look like this:
  ![obraz](https://user-images.githubusercontent.com/26120076/96913281-b98a3780-14a3-11eb-8748-9adfe47fd446.png)
* Make the elytra recipe not lie about its registry name in JEI by actually storing it (and simplify the code by using SpecialRecipe). Just in case some modpack decides to override this or remove manually, I guess. It was just annoying me.
* Make the requirement of applying runes clearer by naming the items "Any Enchanted Item" because it still has the thing where looking up a recipe for one of those items shows all of them in the other slot. Fixing it would mean keeping a single item for each rune or blowing up the number of recipes, so this would at least make it clear.