### PR TITLE
attempt to improving quark caves

### DIFF
--- a/src/main/java/vazkii/quark/base/world/generator/multichunk/ClusterBasedGenerator.java
+++ b/src/main/java/vazkii/quark/base/world/generator/multichunk/ClusterBasedGenerator.java
@@ -34,8 +34,9 @@ public abstract class ClusterBasedGenerator extends MultiChunkFeatureGenerator {
 		final IGenerationContext context = createContext(src, generator, random, chunkCorner, world);
 		
 		forEachChunkBlock(chunkCorner, shape.getLowerBound(), shape.getUpperBound(), (pos) -> {
-			if(shape.isInside(pos))
-				context.consume(pos);
+			double noise = shape.noiseDiff(pos);
+			if(noise > 0)
+				context.consume(pos, noise);
 		});
 		
 		if(context instanceof IFinishableContext)
@@ -45,7 +46,7 @@ public abstract class ClusterBasedGenerator extends MultiChunkFeatureGenerator {
 	public abstract IGenerationContext createContext(BlockPos src, ChunkGenerator generator, Random random, BlockPos chunkCorner, WorldGenRegion world);
 	
 	public static abstract interface IGenerationContext {
-		public void consume(BlockPos pos);
+		public void consume(BlockPos pos, double noise);
 	}
 	
 	public static abstract interface IFinishableContext extends IGenerationContext {

--- a/src/main/java/vazkii/quark/world/gen/BigStoneClusterGenerator.java
+++ b/src/main/java/vazkii/quark/world/gen/BigStoneClusterGenerator.java
@@ -52,7 +52,7 @@ public class BigStoneClusterGenerator extends ClusterBasedGenerator {
 
 	@Override
 	public IGenerationContext createContext(BlockPos src, ChunkGenerator generator, Random random, BlockPos chunkCorner, WorldGenRegion world) {
-		return pos -> {
+		return (pos, noise) -> {
 			if(canPlaceBlock(world, pos))
 				world.setBlockState(pos, placeState, 0);
 		};

--- a/src/main/java/vazkii/quark/world/gen/UndergroundBiomeGenerator.java
+++ b/src/main/java/vazkii/quark/world/gen/UndergroundBiomeGenerator.java
@@ -78,7 +78,7 @@ public class UndergroundBiomeGenerator extends ClusterBasedGenerator {
 		}
 
 		@Override
-		public void consume(BlockPos pos) {
+		public void consume(BlockPos pos, double noise) {
 			info.biomeObj.fill(this, pos);			
 		}
 

--- a/src/main/java/vazkii/quark/world/gen/UndergroundSpaceGenerator.java
+++ b/src/main/java/vazkii/quark/world/gen/UndergroundSpaceGenerator.java
@@ -4,11 +4,12 @@ import java.util.Random;
 
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
+import net.minecraft.block.material.Material;
+import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.biome.Biome;
-import net.minecraft.world.biome.Biome.Category;
 import net.minecraft.world.gen.ChunkGenerator;
 import net.minecraft.world.gen.FlatChunkGenerator;
+import net.minecraft.world.gen.Heightmap;
 import net.minecraft.world.gen.WorldGenRegion;
 import vazkii.quark.base.world.config.ClusterSizeConfig;
 import vazkii.quark.base.world.config.DimensionConfig;
@@ -22,23 +23,87 @@ public class UndergroundSpaceGenerator extends ClusterBasedGenerator {
 
 	@Override
 	public IGenerationContext createContext(BlockPos src, ChunkGenerator generator, Random random, BlockPos chunkCorner, WorldGenRegion world) {
-		return pos -> {
+		return (pos, caveNoise) -> {
 			BlockState state = world.getBlockState(pos);
-			if(state.getBlockHardness(world, pos) > -1) {
-				if(pos.getY() < 6)
-					world.setBlockState(pos, Blocks.LAVA.getDefaultState(), 1);
-				else {
-					Biome biome = getBiome(world, pos);
-					if(biome.getCategory() == Category.OCEAN || biome.getCategory() == Category.BEACH) {
-						BlockState curr = world.getBlockState(pos.up());
-						if(curr.getBlock() == Blocks.WATER)
-							return;
+
+			if(state.getBlockHardness(world, pos) > -1 || state.getMaterial() == Material.LAVA) {
+				if(pos.getY() < 6){
+					world.setBlockState(pos, Blocks.LAVA.getDefaultState(), 1); //flags doesnt do anything during worldgen btw. thanks mojang
+				}
+				else if(noWaterNeighbor(pos, world)){
+					world.setBlockState(pos, Blocks.CAVE_AIR.getDefaultState(), 2);
+
+					// These checks should only happen at edge of cave so by passing the
+					// actual noise all the way here, we can make these checks more efficient
+					// by doing them where they actually matter. (0 is edge of cave)
+					if(caveNoise < 0.06D){
+						removeInvalidBlocksAndEncloseLava(pos, world, state);
 					}
-					
-					world.setBlockState(pos, Blocks.AIR.getDefaultState(), 2);	
 				}
 			}
 		};
+	}
+
+	/**
+	 * Attempt to check above and remove blocks whose position is no longer
+	 * valid once we carved the cave (think tall grass floating and such)
+	 */
+	private static void removeInvalidBlocksAndEncloseLava(BlockPos src, WorldGenRegion world, BlockState state){
+		BlockPos.Mutable mutable = new BlockPos.Mutable().setPos(src);
+
+		for(Direction direction : Direction.values()){
+			mutable.setPos(src).move(direction);
+
+			// Recursive due to nature of some blocks like double tall grass or
+			// stalagemites being multiple blocks that needs to be removed if floating.
+			if(direction == Direction.UP || direction == Direction.DOWN){
+				while(mutable.getY() < world.getHeight() && mutable.getY() > 0 && !world.getBlockState(mutable).isValidPosition(world, mutable)){
+					world.setBlockState(mutable, Blocks.CAVE_AIR.getDefaultState(), 2);
+					mutable.move(direction);
+				}
+			}
+			else{
+				// for sides only
+				if(!world.getBlockState(mutable).isValidPosition(world, mutable)){
+					world.setBlockState(mutable, Blocks.CAVE_AIR.getDefaultState(), 2);
+				}
+			}
+
+			// Enclose lava.
+			if(direction != Direction.DOWN){
+				mutable.setPos(src).move(direction);
+				BlockState neighborBlock = world.getBlockState(mutable);
+				if(neighborBlock.getMaterial() == Material.LAVA){
+					world.setBlockState(mutable, state, 3);
+
+					// Uncomment this if you rather have lava tick update instead of being walled in.
+					world.getPendingFluidTicks().scheduleTick(src, neighborBlock.getFluidState().getFluid(), 0);
+				}
+			}
+		}
+	}
+
+	private static boolean noWaterNeighbor(BlockPos src, WorldGenRegion world){
+		// This prevents extra unnecessary blockpos objects from being made by reusing
+		// a mutable blockpos instead of doing src.add(direction) which would make this
+		// a new blockpos for every direction. If you want to optimize further, make
+		// a mutable be make for the chunk and pass it down all the way here so every
+		// pos in the chunk uses the same mutable for liquid checks too.
+		BlockPos.Mutable mutable = new BlockPos.Mutable();
+
+		for(Direction direction : Direction.values()){
+			//We do not need to check below as fluids only flow sideways or downward.
+			if(direction != Direction.DOWN){
+				BlockState neighborBlock = world.getBlockState(mutable.setPos(src).move(direction));
+				// The heightmap check is to prevent vanilla lake features from floating inside the cave.
+				// Also thickens the buffer between seafloor and cave opening.
+				// Though lakes at surface can still be an issue... screw vanilla lakes
+				if(neighborBlock.getMaterial() == Material.WATER && mutable.getY() > world.getHeight(Heightmap.Type.OCEAN_FLOOR, mutable).getY() - 2){
+					return false;
+				}
+			}
+		}
+		return true;
 	}
 
 	@Override


### PR DESCRIPTION
This PR does several things to try and improve the caves but it isn't perfect of course. Always room for improvement!

Some things it does:

- Tries to surround lava with the carved block to lake lava slopes looks better. This can be removed in favor of just tick updating the lava instead. (works on the majority of lava. There are some lava that is unaffected and I am not sure why. Very odd)

- changed code to not carve blocks under liquids exposed to the sky (ocean floors and rivers) so there is no biome check needed now. (vanilla lake feature towards the surface of the world could cause issues. I hate vanilla lakes lol)

- will now try to remove floating grass and speleothems and such so these kinds of stuff is much rarer. 

- pass in the difference between the target threshold and the noise for carver into the cave. This allows us to do the surrounding block checks only at the end of the cave where the noise difference is a positive number very close to zero. This is a neat optimization that could be used in other clusters to do stuff at the edge of their caves as well.

Feel free to do whatever you want with this code! 

pic of current lava shelf fix:
![image](https://user-images.githubusercontent.com/40846040/97767673-04cfc600-1af4-11eb-9adc-0d26c6a3254c.png)

