### PR TITLE
Fix several planes which were not properly mirrored from behind

### DIFF
--- a/src/main/resources/assets/quark/models/block/burnt_vine_1.json
+++ b/src/main/resources/assets/quark/models/block/burnt_vine_1.json
@@ -10,7 +10,7 @@
             "shade": false,
             "faces": {
                 "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "south": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine", "tintindex": 0 }
             }
         }
     ]

--- a/src/main/resources/assets/quark/models/block/burnt_vine_1u.json
+++ b/src/main/resources/assets/quark/models/block/burnt_vine_1u.json
@@ -10,7 +10,7 @@
             "shade": false,
             "faces": {
                 "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "up":    { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#vine", "tintindex": 0 }
             }
         },
         {   "from": [ 0, 0, 15.2 ],
@@ -18,7 +18,7 @@
             "shade": false,
             "faces": {
                 "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "south": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine", "tintindex": 0 }
             }
         }
     ]

--- a/src/main/resources/assets/quark/models/block/burnt_vine_2.json
+++ b/src/main/resources/assets/quark/models/block/burnt_vine_2.json
@@ -9,7 +9,7 @@
             "to": [ 16, 16, 0.8 ],
             "shade": false,
             "faces": {
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
+                "north": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine", "tintindex": 0 },
                 "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
             }
         },
@@ -18,7 +18,7 @@
             "shade": false,
             "faces": {
                 "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "east": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine", "tintindex": 0 }
             }
         }
     ]

--- a/src/main/resources/assets/quark/models/block/burnt_vine_2_opposite.json
+++ b/src/main/resources/assets/quark/models/block/burnt_vine_2_opposite.json
@@ -10,14 +10,14 @@
             "shade": false,
             "faces": {
                 "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "east": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine", "tintindex": 0 }
             }
         },
         {   "from": [ 0.8, 0, 0 ],
             "to": [ 0.8, 16, 16 ],
             "shade": false,
             "faces": {
-                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
+                "west": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine", "tintindex": 0 },
                 "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
             }
         }

--- a/src/main/resources/assets/quark/models/block/burnt_vine_2u.json
+++ b/src/main/resources/assets/quark/models/block/burnt_vine_2u.json
@@ -10,14 +10,14 @@
             "shade": false,
             "faces": {
                 "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "up":    { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#vine", "tintindex": 0 }
             }
         },
         {   "from": [ 0, 0, 0.8 ],
             "to": [ 16, 16, 0.8 ],
             "shade": false,
             "faces": {
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
+                "north": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine", "tintindex": 0 },
                 "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
             }
         },
@@ -26,7 +26,7 @@
             "shade": false,
             "faces": {
                 "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "east": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine", "tintindex": 0 }
             }
         }
     ]

--- a/src/main/resources/assets/quark/models/block/burnt_vine_2u_opposite.json
+++ b/src/main/resources/assets/quark/models/block/burnt_vine_2u_opposite.json
@@ -10,7 +10,7 @@
             "shade": false,
             "faces": {
                 "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "up":    { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#vine", "tintindex": 0 }
             }
         },
         {   "from": [ 15.2, 0, 0 ],
@@ -18,14 +18,14 @@
             "shade": false,
             "faces": {
                 "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "east": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine", "tintindex": 0 }
             }
         },
         {   "from": [ 0.8, 0, 0 ],
             "to": [ 0.8, 16, 16 ],
             "shade": false,
             "faces": {
-                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
+                "west": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine", "tintindex": 0 },
                 "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
             }
         }

--- a/src/main/resources/assets/quark/models/block/burnt_vine_3.json
+++ b/src/main/resources/assets/quark/models/block/burnt_vine_3.json
@@ -10,7 +10,7 @@
             "shade": false,
             "faces": {
                 "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "east": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine", "tintindex": 0 }
             }
         },
         {   "from": [ 0, 0, 15.2 ],
@@ -18,14 +18,14 @@
             "shade": false,
             "faces": {
                 "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "south": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine", "tintindex": 0 }
             }
         },
         {   "from": [ 0, 0, 0.8 ],
             "to": [ 16, 16, 0.8 ],
             "shade": false,
             "faces": {
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
+                "north": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine", "tintindex": 0 },
                 "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
             }
         }

--- a/src/main/resources/assets/quark/models/block/burnt_vine_3u.json
+++ b/src/main/resources/assets/quark/models/block/burnt_vine_3u.json
@@ -10,7 +10,7 @@
             "shade": false,
             "faces": {
                 "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "up":    { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#vine", "tintindex": 0 }
             }
         },
         {   "from": [ 15.2, 0, 0 ],
@@ -18,7 +18,7 @@
             "shade": false,
             "faces": {
                 "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "east": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine", "tintindex": 0 }
             }
         },
         {   "from": [ 0, 0, 15.2 ],
@@ -26,14 +26,14 @@
             "shade": false,
             "faces": {
                 "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "south": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine", "tintindex": 0 }
             }
         },
         {   "from": [ 0, 0, 0.8 ],
             "to": [ 16, 16, 0.8 ],
             "shade": false,
             "faces": {
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
+                "north": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine", "tintindex": 0 },
                 "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
             }
         }

--- a/src/main/resources/assets/quark/models/block/burnt_vine_4.json
+++ b/src/main/resources/assets/quark/models/block/burnt_vine_4.json
@@ -9,7 +9,7 @@
             "to": [ 0.8, 16, 16 ],
             "shade": false,
             "faces": {
-                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
+                "west": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine", "tintindex": 0 },
                 "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
             }
         },
@@ -18,7 +18,7 @@
             "shade": false,
             "faces": {
                 "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "east": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine", "tintindex": 0 }
             }
         },
         {   "from": [ 0, 0, 15.2 ],
@@ -26,14 +26,14 @@
             "shade": false,
             "faces": {
                 "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "south": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine", "tintindex": 0 }
             }
         },
         {   "from": [ 0, 0, 0.8 ],
             "to": [ 16, 16, 0.8 ],
             "shade": false,
             "faces": {
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
+                "north": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine", "tintindex": 0 },
                 "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
             }
         }

--- a/src/main/resources/assets/quark/models/block/burnt_vine_4u.json
+++ b/src/main/resources/assets/quark/models/block/burnt_vine_4u.json
@@ -10,14 +10,14 @@
             "shade": false,
             "faces": {
                 "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "up":    { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#vine", "tintindex": 0 }
             }
         },
         {   "from": [ 0.8, 0, 0 ],
             "to": [ 0.8, 16, 16 ],
             "shade": false,
             "faces": {
-                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
+                "west": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine", "tintindex": 0 },
                 "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
             }
         },
@@ -26,7 +26,7 @@
             "shade": false,
             "faces": {
                 "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "east": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine", "tintindex": 0 }
             }
         },
         {   "from": [ 0, 0, 15.2 ],
@@ -34,14 +34,14 @@
             "shade": false,
             "faces": {
                 "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "south": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine", "tintindex": 0 }
             }
         },
         {   "from": [ 0, 0, 0.8 ],
             "to": [ 16, 16, 0.8 ],
             "shade": false,
             "faces": {
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
+                "north": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine", "tintindex": 0 },
                 "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
             }
         }

--- a/src/main/resources/assets/quark/models/block/burnt_vine_u.json
+++ b/src/main/resources/assets/quark/models/block/burnt_vine_u.json
@@ -10,7 +10,7 @@
             "shade": false,
             "faces": {
                 "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "up":    { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#vine", "tintindex": 0 }
             }
         }
     ]

--- a/src/main/resources/assets/quark/models/block/ladder_but_not_the_vanilla_one_so_resourcepacks_dont_override_it.json
+++ b/src/main/resources/assets/quark/models/block/ladder_but_not_the_vanilla_one_so_resourcepacks_dont_override_it.json
@@ -10,7 +10,7 @@
             "shade": false,
             "faces": {
                 "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#texture" },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#texture" }
+                "south": { "uv": [ 16, 0, 0, 16 ], "texture": "#texture" }
             }
         }
     ]

--- a/src/main/resources/assets/quark/models/block/root_1.json
+++ b/src/main/resources/assets/quark/models/block/root_1.json
@@ -9,8 +9,8 @@
             "to": [ 16, 16, 15.2 ],
             "shade": false,
             "faces": {
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" },
+                "south": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine" }
             }
         }
     ]

--- a/src/main/resources/assets/quark/models/block/root_1u.json
+++ b/src/main/resources/assets/quark/models/block/root_1u.json
@@ -9,16 +9,16 @@
             "to": [ 16, 15.2, 16 ],
             "shade": false,
             "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "up":    { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" },
+                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#vine" }
             }
         },
         {   "from": [ 0, 0, 15.2 ],
             "to": [ 16, 16, 15.2 ],
             "shade": false,
             "faces": {
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" },
+                "south": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine" }
             }
         }
     ]

--- a/src/main/resources/assets/quark/models/block/root_2.json
+++ b/src/main/resources/assets/quark/models/block/root_2.json
@@ -9,16 +9,16 @@
             "to": [ 16, 16, 0.8 ],
             "shade": false,
             "faces": {
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "north": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine" },
+                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" }
             }
         },
         {   "from": [ 15.2, 0, 0 ],
             "to": [ 15.2, 16, 16 ],
             "shade": false,
             "faces": {
-                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" },
+                "east": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine" }
             }
         }
     ]

--- a/src/main/resources/assets/quark/models/block/root_2_opposite.json
+++ b/src/main/resources/assets/quark/models/block/root_2_opposite.json
@@ -9,16 +9,16 @@
             "to": [ 15.2, 16, 16 ],
             "shade": false,
             "faces": {
-                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" },
+                "east": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine" }
             }
         },
         {   "from": [ 0.8, 0, 0 ],
             "to": [ 0.8, 16, 16 ],
             "shade": false,
             "faces": {
-                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "west": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine" },
+                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" }
             }
         }
     ]

--- a/src/main/resources/assets/quark/models/block/root_2u.json
+++ b/src/main/resources/assets/quark/models/block/root_2u.json
@@ -9,24 +9,24 @@
             "to": [ 16, 15.2, 16 ],
             "shade": false,
             "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "up":    { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" },
+                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#vine" }
             }
         },
         {   "from": [ 0, 0, 0.8 ],
             "to": [ 16, 16, 0.8 ],
             "shade": false,
             "faces": {
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "north": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine" },
+                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" }
             }
         },
         {   "from": [ 15.2, 0, 0 ],
             "to": [ 15.2, 16, 16 ],
             "shade": false,
             "faces": {
-                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" },
+                "east": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine" }
             }
         }
     ]

--- a/src/main/resources/assets/quark/models/block/root_2u_opposite.json
+++ b/src/main/resources/assets/quark/models/block/root_2u_opposite.json
@@ -9,24 +9,24 @@
             "to": [ 16, 15.2, 16 ],
             "shade": false,
             "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "up":    { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" },
+                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#vine" }
             }
         },
         {   "from": [ 15.2, 0, 0 ],
             "to": [ 15.2, 16, 16 ],
             "shade": false,
             "faces": {
-                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" },
+                "east": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine" }
             }
         },
         {   "from": [ 0.8, 0, 0 ],
             "to": [ 0.8, 16, 16 ],
             "shade": false,
             "faces": {
-                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "west": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine" },
+                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" }
             }
         }
     ]

--- a/src/main/resources/assets/quark/models/block/root_3.json
+++ b/src/main/resources/assets/quark/models/block/root_3.json
@@ -9,24 +9,24 @@
             "to": [ 15.2, 16, 16 ],
             "shade": false,
             "faces": {
-                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" },
+                "east": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine" }
             }
         },
         {   "from": [ 0, 0, 15.2 ],
             "to": [ 16, 16, 15.2 ],
             "shade": false,
             "faces": {
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" },
+                "south": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine" }
             }
         },
         {   "from": [ 0, 0, 0.8 ],
             "to": [ 16, 16, 0.8 ],
             "shade": false,
             "faces": {
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "north": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine" },
+                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" }
             }
         }
     ]

--- a/src/main/resources/assets/quark/models/block/root_3u.json
+++ b/src/main/resources/assets/quark/models/block/root_3u.json
@@ -9,32 +9,32 @@
             "to": [ 16, 15.2, 16 ],
             "shade": false,
             "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "up":    { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" },
+                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#vine" }
             }
         },
         {   "from": [ 15.2, 0, 0 ],
             "to": [ 15.2, 16, 16 ],
             "shade": false,
             "faces": {
-                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" },
+                "east": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine" }
             }
         },
         {   "from": [ 0, 0, 15.2 ],
             "to": [ 16, 16, 15.2 ],
             "shade": false,
             "faces": {
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" },
+                "south": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine" }
             }
         },
         {   "from": [ 0, 0, 0.8 ],
             "to": [ 16, 16, 0.8 ],
             "shade": false,
             "faces": {
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "north": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine" },
+                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" }
             }
         }
     ]

--- a/src/main/resources/assets/quark/models/block/root_4.json
+++ b/src/main/resources/assets/quark/models/block/root_4.json
@@ -9,32 +9,32 @@
             "to": [ 0.8, 16, 16 ],
             "shade": false,
             "faces": {
-                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "west": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine" },
+                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" }
             }
         },
         {   "from": [ 15.2, 0, 0 ],
             "to": [ 15.2, 16, 16 ],
             "shade": false,
             "faces": {
-                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" },
+                "east": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine" }
             }
         },
         {   "from": [ 0, 0, 15.2 ],
             "to": [ 16, 16, 15.2 ],
             "shade": false,
             "faces": {
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" },
+                "south": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine" }
             }
         },
         {   "from": [ 0, 0, 0.8 ],
             "to": [ 16, 16, 0.8 ],
             "shade": false,
             "faces": {
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "north": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine" },
+                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" }
             }
         }
     ]

--- a/src/main/resources/assets/quark/models/block/root_4u.json
+++ b/src/main/resources/assets/quark/models/block/root_4u.json
@@ -9,40 +9,40 @@
             "to": [ 16, 15.2, 16 ],
             "shade": false,
             "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "up":    { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" },
+                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#vine" }
             }
         },
         {   "from": [ 0.8, 0, 0 ],
             "to": [ 0.8, 16, 16 ],
             "shade": false,
             "faces": {
-                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "west": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine" },
+                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" }
             }
         },
         {   "from": [ 15.2, 0, 0 ],
             "to": [ 15.2, 16, 16 ],
             "shade": false,
             "faces": {
-                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" },
+                "east": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine" }
             }
         },
         {   "from": [ 0, 0, 15.2 ],
             "to": [ 16, 16, 15.2 ],
             "shade": false,
             "faces": {
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" },
+                "south": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine" }
             }
         },
         {   "from": [ 0, 0, 0.8 ],
             "to": [ 16, 16, 0.8 ],
             "shade": false,
             "faces": {
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "north": { "uv": [ 16, 0, 0, 16 ], "texture": "#vine" },
+                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" }
             }
         }
     ]

--- a/src/main/resources/assets/quark/models/block/root_u.json
+++ b/src/main/resources/assets/quark/models/block/root_u.json
@@ -9,8 +9,8 @@
             "to": [ 16, 15.2, 16 ],
             "shade": false,
             "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#vine", "tintindex": 0 }
+                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#vine" },
+                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#vine" }
             }
         }
     ]

--- a/src/main/resources/assets/quark/models/block/root_u.json
+++ b/src/main/resources/assets/quark/models/block/root_u.json
@@ -10,7 +10,7 @@
             "shade": false,
             "faces": {
                 "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 },
-                "up":    { "uv": [ 0, 0, 16, 16 ], "texture": "#vine", "tintindex": 0 }
+                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#vine", "tintindex": 0 }
             }
         }
     ]


### PR DESCRIPTION
- Fixes #2719
- Also decided to fix this for burnt vines and ladders since they were affected by the same thing
- Removed the tint index parameter from cave roots since it didn't seem to be actually doing anything and was left over from the normal vine model