### PR TITLE
[Compat] [Charm] Mark modules as enabled earlier

### DIFF
--- a/src/main/java/vazkii/quark/base/proxy/CommonProxy.java
+++ b/src/main/java/vazkii/quark/base/proxy/CommonProxy.java
@@ -27,7 +27,7 @@ import vazkii.quark.base.world.WorldGenHandler;
 
 public class CommonProxy {
 
-	private int lastConfigChange = 0;
+	private int lastConfigChange = Integer.MIN_VALUE;
 	public static boolean jingleTheBells = false;
 	
 	public void start() {


### PR DESCRIPTION
Coming over from charm again: 
We're trying to check if quark modules are enabled in `FMLCommonSetupEvent` (to disable our modules which would do the same).
Quark currently marks its modules as enabled during that phase, which is a parallel event and leads to race conditions with our checks.

This change lets the very first `ModConfigEvent` through, which means Quarks modules are marked as enabled before `FMLCommonSetupEvent` starts.
We hope this works for you. Let me know if further discussion is necessary.