### PR TITLE
[Compat] [Charm] [Now really] Mark modules as enabled earlier

### DIFF
--- a/src/main/java/vazkii/quark/base/proxy/CommonProxy.java
+++ b/src/main/java/vazkii/quark/base/proxy/CommonProxy.java
@@ -26,7 +26,7 @@ import vazkii.quark.base.world.WorldGenHandler;
 
 public class CommonProxy {
 
-	private int lastConfigChange = Integer.MIN_VALUE;
+	private int lastConfigChange = -10;
 	public static boolean jingleTheBells = false;
 	
 	public void start() {


### PR DESCRIPTION
The change in #2754 did not have the intended effect due to an integer overflow. Change the number the be the same as the one in L69.

Sorry for wasting your time with the first PR.