### PR TITLE
Inherit from pressure plate block implementation

### DIFF
--- a/src/main/java/vazkii/quark/base/block/QuarkPressurePlateBlock.java
+++ b/src/main/java/vazkii/quark/base/block/QuarkPressurePlateBlock.java
@@ -1,6 +1,6 @@
 package vazkii.quark.base.block;
 
-import net.minecraft.block.AbstractPressurePlateBlock;
+import net.minecraft.block.PressurePlateBlock;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
@@ -14,13 +14,13 @@ import java.util.function.BooleanSupplier;
  * @author WireSegal
  * Created at 9:41 PM on 10/8/19.
  */
-public abstract class QuarkPressurePlateBlock extends AbstractPressurePlateBlock implements IQuarkBlock {
+public abstract class QuarkPressurePlateBlock extends PressurePlateBlock implements IQuarkBlock {
 
     private final QuarkModule module;
     private BooleanSupplier enabledSupplier = () -> true;
 
-    public QuarkPressurePlateBlock(String regname, QuarkModule module, ItemGroup creativeTab, Properties properties) {
-        super(properties);
+    public QuarkPressurePlateBlock(Sensitivity sensitivity, String regname, QuarkModule module, ItemGroup creativeTab, Properties properties) {
+        super(sensitivity, properties);
         this.module = module;
 
         RegistryHelper.registerBlock(this, regname);

--- a/src/main/java/vazkii/quark/content/automation/block/ObsidianPressurePlateBlock.java
+++ b/src/main/java/vazkii/quark/content/automation/block/ObsidianPressurePlateBlock.java
@@ -5,8 +5,11 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.state.BooleanProperty;
 import net.minecraft.state.properties.BlockStateProperties;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.util.SoundEvents;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IWorld;
 import net.minecraft.world.World;
 import vazkii.quark.base.block.QuarkPressurePlateBlock;
 import vazkii.quark.base.module.QuarkModule;
@@ -24,6 +27,16 @@ public class ObsidianPressurePlateBlock extends QuarkPressurePlateBlock {
     public ObsidianPressurePlateBlock(String regname, QuarkModule module, ItemGroup creativeTab, Properties properties) {
         super(null /*Sensitivity is unused*/, regname, module, creativeTab, properties);
         this.setDefaultState(getDefaultState().with(POWERED, false));
+    }
+
+    @Override
+    protected void playClickOnSound(@Nonnull IWorld worldIn, @Nonnull BlockPos pos) {
+        worldIn.playSound(null, pos, SoundEvents.BLOCK_STONE_PRESSURE_PLATE_CLICK_ON, SoundCategory.BLOCKS, 0.3F, 0.5F);
+    }
+
+    @Override
+    protected void playClickOffSound(@Nonnull IWorld worldIn, @Nonnull BlockPos pos) {
+        worldIn.playSound(null, pos, SoundEvents.BLOCK_STONE_PRESSURE_PLATE_CLICK_OFF, SoundCategory.BLOCKS, 0.3F, 0.4F);
     }
 
     @Override

--- a/src/main/java/vazkii/quark/content/automation/block/ObsidianPressurePlateBlock.java
+++ b/src/main/java/vazkii/quark/content/automation/block/ObsidianPressurePlateBlock.java
@@ -1,18 +1,12 @@
 package vazkii.quark.content.automation.block;
 
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.state.BooleanProperty;
-import net.minecraft.state.StateContainer;
 import net.minecraft.state.properties.BlockStateProperties;
-import net.minecraft.util.SoundCategory;
-import net.minecraft.util.SoundEvents;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.IWorld;
 import net.minecraft.world.World;
 import vazkii.quark.base.block.QuarkPressurePlateBlock;
 import vazkii.quark.base.module.QuarkModule;
@@ -28,18 +22,8 @@ public class ObsidianPressurePlateBlock extends QuarkPressurePlateBlock {
     public static final BooleanProperty POWERED = BlockStateProperties.POWERED;
 
     public ObsidianPressurePlateBlock(String regname, QuarkModule module, ItemGroup creativeTab, Properties properties) {
-        super(regname, module, creativeTab, properties);
+        super(null /*Sensitivity is unused*/, regname, module, creativeTab, properties);
         this.setDefaultState(getDefaultState().with(POWERED, false));
-    }
-
-    @Override
-    protected void playClickOnSound(@Nonnull IWorld worldIn, @Nonnull BlockPos pos) {
-        worldIn.playSound(null, pos, SoundEvents.BLOCK_STONE_PRESSURE_PLATE_CLICK_ON, SoundCategory.BLOCKS, 0.3F, 0.5F);
-    }
-
-    @Override
-    protected void playClickOffSound(@Nonnull IWorld worldIn, @Nonnull BlockPos pos) {
-        worldIn.playSound(null, pos, SoundEvents.BLOCK_STONE_PRESSURE_PLATE_CLICK_OFF, SoundCategory.BLOCKS, 0.3F, 0.4F);
     }
 
     @Override
@@ -56,21 +40,5 @@ public class ObsidianPressurePlateBlock extends QuarkPressurePlateBlock {
         }
 
         return 0;
-    }
-
-    @Override
-    protected int getRedstoneStrength(@Nonnull BlockState state) {
-        return state.get(POWERED) ? 15 : 0;
-    }
-
-    @Nonnull
-    @Override
-    protected BlockState setRedstoneStrength(@Nonnull BlockState state, int strength) {
-        return state.with(POWERED, strength > 0);
-    }
-
-    @Override
-    protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
-        builder.add(POWERED);
     }
 }


### PR DESCRIPTION
This cleans up the implementation for the obsidian pressure plates, allowing third parties to be indirectly aware of the `POWERED` property due to being in the hierarchy of `PressurePlateBlock`. Also just allows for removal of a lot of code already provided by Mojang's implementation. If weighted pressure plates or other entirely custom implementations are needed in the future, they can always have their own boilerplate classes.