### PR TITLE
Add compatibility with Lootr for obsidian pillars.

### DIFF
--- a/src/main/java/vazkii/quark/content/world/gen/ObsidianSpikeGenerator.java
+++ b/src/main/java/vazkii/quark/content/world/gen/ObsidianSpikeGenerator.java
@@ -7,6 +7,7 @@ import net.minecraft.block.Blocks;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.EntityType;
 import net.minecraft.tileentity.ChestTileEntity;
+import net.minecraft.tileentity.LockableLootTileEntity;
 import net.minecraft.tileentity.MobSpawnerTileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.ResourceLocation;
@@ -101,7 +102,7 @@ public class ObsidianSpikeGenerator extends Generator {
 				
 				placePos = placePos.down();
 				world.setBlockState(placePos, Blocks.CHEST.getDefaultState(), 0);
-				((ChestTileEntity) world.getTileEntity(placePos)).setLootTable(new ResourceLocation("minecraft", "chests/nether_bridge"), rand.nextLong());
+				LockableLootTileEntity.setLootTable(world, rand, placePos, new ResourceLocation("minecraft", "chests/nether_bridge"));
 			}
 		}
 	}


### PR DESCRIPTION
This was a request on my tracker. Unfortunately, it's not possible for me to hook into the tile entity's `setLootTable` method as the tile has no context around it allowing me to replace it with a Lootr chest.

Using the LockableLootTileEntity's `setLootTable` static method, on the other hand, provides all of the ncessary information, and is otherwise identical to the previous `setLootTable` statement. 

Actually, in theory this introduces a check to make sure that the tile entity is valid rather than simply casting -- in the very rare instance where setblockstate fails to properly create a tile entity for some reason.