### PR TITLE
Made SpeleothemBlock easier for other mods to detect if it is in a valid spot

### DIFF
--- a/src/main/java/vazkii/quark/content/world/block/SpeleothemBlock.java
+++ b/src/main/java/vazkii/quark/content/world/block/SpeleothemBlock.java
@@ -4,10 +4,7 @@ import java.util.Locale;
 
 import javax.annotation.Nonnull;
 
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.IWaterLoggable;
-import net.minecraft.block.SoundType;
+import net.minecraft.block.*;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.material.MaterialColor;
 import net.minecraft.fluid.FluidState;
@@ -20,11 +17,13 @@ import net.minecraft.state.EnumProperty;
 import net.minecraft.state.StateContainer.Builder;
 import net.minecraft.state.properties.BlockStateProperties;
 import net.minecraft.tags.FluidTags;
+import net.minecraft.util.Direction;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
+import net.minecraft.world.IWorld;
 import net.minecraft.world.IWorldReader;
 import net.minecraft.world.World;
 import vazkii.quark.base.block.QuarkBlock;
@@ -48,7 +47,23 @@ public class SpeleothemBlock extends QuarkBlock implements IWaterLoggable {
 	public boolean isValidPosition(BlockState state, IWorldReader worldIn, BlockPos pos) {
 		return getBearing(worldIn, pos) > 0;
 	}
-	
+
+	@Deprecated
+	public BlockState updatePostPlacement(BlockState stateIn, Direction facing, BlockState facingState, IWorld worldIn, BlockPos currentPos, BlockPos facingPos) {
+		if(stateIn.getBlock() instanceof SpeleothemBlock){
+			boolean invalidSpot = getBearing(worldIn, currentPos) < stateIn.get(SIZE).strength + 1;
+			if(invalidSpot){
+				if(stateIn.get(WATERLOGGED)){
+					stateIn = Blocks.WATER.getDefaultState();
+				}
+				else{
+					stateIn = Blocks.AIR.getDefaultState();
+				}
+			}
+		}
+		return stateIn;
+	}
+
 	@Override
 	public BlockState getStateForPlacement(BlockItemUseContext context) {
 		SpeleothemSize size = SpeleothemSize.values()[Math.max(0, getBearing(context.getWorld(), context.getPos()) - 1)];


### PR DESCRIPTION
This PR does not change any behavior that the user can see. The block still can be placed, will break if it loses support and all that.

What this PR does is by making SpeleothemBlock override updatePostPlacement, it makes it much easier for other mods to know if the SpeleothemBlock is in a valid spot with support or if it should be replaced. For example: https://github.com/TelepathicGrunt/WorldBlender/blob/0f55409be94510c365f4773f793b78d2a2af44a3/src/main/java/com/telepathicgrunt/worldblender/entities/ItemClearingEntity.java#L84

My mod World Blender will iterate over the chaotic landscape and remove all blocks that are in invalid placements such as floating plants or flowers on non-dirt blocks. I found that Quark's Speleothems were not returning the correct state from getValidBlockForPosition despite that method working correctly for most vanilla blocks. Hence this PR to help make the Speleothems now properly return the correct state for getValidBlockForPosition and allow other mods to know what state should be at the spot.

I hope this helps! getValidBlockForPosition can be quite useful for lots of stuff