### PR TITLE
Improve pickarang compatibility

### DIFF
--- a/src/main/java/vazkii/quark/content/tools/entity/PickarangEntity.java
+++ b/src/main/java/vazkii/quark/content/tools/entity/PickarangEntity.java
@@ -457,10 +457,7 @@ public class PickarangEntity extends ProjectileEntity {
 					if (player.isAlive()) {
 						for (ItemEntity item : items)
 							if(item.isAlive()) {
-								ItemStack drop = item.getItem();
-								if (!player.addItemStackToInventory(drop))
-									player.dropItem(drop, false);
-								item.remove();
+								giveItemToPlayer(player, item);
 							}
 
 						for (ExperienceOrbEntity xpOrb : xp) 
@@ -472,10 +469,7 @@ public class PickarangEntity extends ProjectileEntity {
 								continue;
 
 							if (riding instanceof ItemEntity) {
-								ItemStack drop = ((ItemEntity) riding).getItem();
-								if (!player.addItemStackToInventory(drop))
-									player.dropItem(drop, false);
-								riding.remove();
+								giveItemToPlayer(player, (ItemEntity) riding);
 							} else if (riding instanceof ExperienceOrbEntity)
 								riding.onCollideWithPlayer(player);
 						}
@@ -485,6 +479,18 @@ public class PickarangEntity extends ProjectileEntity {
 				}
 			} else
 				setMotion(motion.normalize().scale(0.7 + eff * 0.325F));
+		}
+	}
+
+	private void giveItemToPlayer(PlayerEntity player, ItemEntity itemEntity) {
+		itemEntity.setPickupDelay(0);
+		itemEntity.onCollideWithPlayer(player);
+
+		if (itemEntity.isAlive()) {
+			// Player could not pick up everything
+			ItemStack drop = itemEntity.getItem();
+			player.dropItem(drop, false);
+			itemEntity.remove();
 		}
 	}
 

--- a/src/main/java/vazkii/quark/content/tools/entity/PickarangEntity.java
+++ b/src/main/java/vazkii/quark/content/tools/entity/PickarangEntity.java
@@ -456,9 +456,8 @@ public class PickarangEntity extends ProjectileEntity {
 
 					if (player.isAlive()) {
 						for (ItemEntity item : items)
-							if(item.isAlive()) {
+							if(item.isAlive())
 								giveItemToPlayer(player, item);
-							}
 
 						for (ExperienceOrbEntity xpOrb : xp) 
 							if(xpOrb.isAlive())
@@ -468,9 +467,9 @@ public class PickarangEntity extends ProjectileEntity {
 							if (!riding.isAlive())
 								continue;
 
-							if (riding instanceof ItemEntity) {
+							if (riding instanceof ItemEntity)
 								giveItemToPlayer(player, (ItemEntity) riding);
-							} else if (riding instanceof ExperienceOrbEntity)
+							else if (riding instanceof ExperienceOrbEntity)
 								riding.onCollideWithPlayer(player);
 						}
 					}


### PR DESCRIPTION
Makes the pickarang compatible with mods that hook item pickup events, for example [Shulker Enchantments](https://github.com/Ephys/mc-shulker-enchantments). (The siphon enchantment used to not work for items returning on a pickarang.)

Should not alter game mechanics in standalone Quark. I've tested it alone and with the Shulker Enchantments mod.

Does not touch the code for picking up the pickarang itself, only the items on it. The pickarang is special cased to go into exactly the slot you threw it from, so I don't think it should be hookable by other mods.