### PR TITLE
Allow enchantment influencers to modify influenced enchantments

### DIFF
--- a/src/main/java/vazkii/quark/addons/oddities/block/MatrixEnchantingTableBlock.java
+++ b/src/main/java/vazkii/quark/addons/oddities/block/MatrixEnchantingTableBlock.java
@@ -12,9 +12,6 @@ import net.minecraft.block.EnchantingTableBlock;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.ServerPlayerEntity;
-import net.minecraft.inventory.container.EnchantmentContainer;
-import net.minecraft.inventory.container.INamedContainerProvider;
-import net.minecraft.inventory.container.SimpleNamedContainerProvider;
 import net.minecraft.item.DyeColor;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemStack;
@@ -23,7 +20,6 @@ import net.minecraft.particles.RedstoneParticleData;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Hand;
-import net.minecraft.util.IWorldPosCallable;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
@@ -37,6 +33,7 @@ import vazkii.arl.util.RegistryHelper;
 import vazkii.quark.addons.oddities.module.MatrixEnchantingModule;
 import vazkii.quark.addons.oddities.tile.MatrixEnchantingTableTileEntity;
 import vazkii.quark.api.IEnchantmentInfluencer;
+import vazkii.quark.api.IModifiableEnchantmentInfluencer;
 import vazkii.quark.base.block.IQuarkBlock;
 import vazkii.quark.base.module.ModuleLoader;
 import vazkii.quark.base.module.QuarkModule;
@@ -116,18 +113,24 @@ public class MatrixEnchantingTableBlock extends EnchantingTableBlock implements 
 					for(int k = 0; k <= 1; ++k) {
 						BlockPos blockpos = pos.add(i, k, j);
 						BlockState state = worldIn.getBlockState(blockpos); 
-						if(state.getEnchantPowerBonus(worldIn, pos) > 0) {
+						if(state.getEnchantPowerBonus(worldIn, blockpos) > 0) {
 							BlockPos test = pos.add(i / 2, 0, j / 2);
 							if(!(worldIn.isAirBlock(test) || (allowUnderwater && worldIn.getBlockState(test).getBlock() == Blocks.WATER)))
 								break;
 							
 							if(showInfluences && state.getBlock() instanceof IEnchantmentInfluencer) {
-								DyeColor color = ((IEnchantmentInfluencer) state.getBlock()).getEnchantmentInfluenceColor(worldIn, blockpos, state);
+							    IEnchantmentInfluencer influencer = (IEnchantmentInfluencer) state.getBlock();
+								DyeColor color = influencer.getEnchantmentInfluenceColor(worldIn, blockpos, state);
 								
 								if(color != null) {
 									float[] comp = color.getColorComponentValues();
-									
-									int steps = 20;
+
+                                    if(influencer instanceof IModifiableEnchantmentInfluencer) {
+                                        IModifiableEnchantmentInfluencer modifiableInfluencer = (IModifiableEnchantmentInfluencer) influencer;
+                                        comp = modifiableInfluencer.getModifiedColorComponents(worldIn, blockpos, state, comp);
+                                    }
+
+                                    int steps = 20;
 									double dx = (double) (pos.getX() - blockpos.getX()) / steps;
 									double dy = (double) (pos.getY() - blockpos.getY()) / steps;
 									double dz = (double) (pos.getZ() - blockpos.getZ()) / steps;

--- a/src/main/java/vazkii/quark/addons/oddities/tile/MatrixEnchantingTableTileEntity.java
+++ b/src/main/java/vazkii/quark/addons/oddities/tile/MatrixEnchantingTableTileEntity.java
@@ -269,12 +269,14 @@ public class MatrixEnchantingTableTileEntity extends BaseEnchantingTableTile imp
 				
 				if(ord != null) {
 					List<Enchantment> influencedEnchants = MatrixEnchantingModule.candleInfluences.get(ord);
-					if(influencedEnchants != null)
-						for(Enchantment e : influencedEnchants) {
-							int curr = influences.getOrDefault(e, 0);
-							if(curr < MatrixEnchantingModule.influenceMax)
-								influences.put(e, Math.min(MatrixEnchantingModule.influenceMax, curr + count));
-						}
+					if(influencedEnchants != null) {
+					    influencer.modifyInfluencedEnchantments(world, pos, state, getStackInSlot(0), influencedEnchants);
+                        for(Enchantment e : influencedEnchants) {
+                            int curr = influences.getOrDefault(e, 0);
+                            if(curr < MatrixEnchantingModule.influenceMax)
+                                influences.put(e, Math.min(MatrixEnchantingModule.influenceMax, curr + count));
+                        }
+                    }
 				}
 			}
 		}

--- a/src/main/java/vazkii/quark/addons/oddities/tile/MatrixEnchantingTableTileEntity.java
+++ b/src/main/java/vazkii/quark/addons/oddities/tile/MatrixEnchantingTableTileEntity.java
@@ -1,5 +1,6 @@
 package vazkii.quark.addons.oddities.tile;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -268,7 +269,7 @@ public class MatrixEnchantingTableTileEntity extends BaseEnchantingTableTile imp
 				int count = influencer.getInfluenceStack(world, pos, state);
 				
 				if(ord != null) {
-					List<Enchantment> influencedEnchants = MatrixEnchantingModule.candleInfluences.get(ord);
+					List<Enchantment> influencedEnchants = new ArrayList<>(MatrixEnchantingModule.candleInfluences.get(ord));
 					if(influencedEnchants != null) {
 					    influencer.modifyInfluencedEnchantments(world, pos, state, getStackInSlot(0), influencedEnchants);
                         for(Enchantment e : influencedEnchants) {

--- a/src/main/java/vazkii/quark/addons/oddities/tile/MatrixEnchantingTableTileEntity.java
+++ b/src/main/java/vazkii/quark/addons/oddities/tile/MatrixEnchantingTableTileEntity.java
@@ -33,6 +33,7 @@ import vazkii.quark.addons.oddities.container.MatrixEnchantingContainer;
 import vazkii.quark.addons.oddities.container.EnchantmentMatrix.Piece;
 import vazkii.quark.addons.oddities.module.MatrixEnchantingModule;
 import vazkii.quark.api.IEnchantmentInfluencer;
+import vazkii.quark.api.IModifiableEnchantmentInfluencer;
 
 public class MatrixEnchantingTableTileEntity extends BaseEnchantingTableTile implements INamedContainerProvider {
 
@@ -269,9 +270,12 @@ public class MatrixEnchantingTableTileEntity extends BaseEnchantingTableTile imp
 				int count = influencer.getInfluenceStack(world, pos, state);
 				
 				if(ord != null) {
-					List<Enchantment> influencedEnchants = new ArrayList<>(MatrixEnchantingModule.candleInfluences.get(ord));
+					List<Enchantment> influencedEnchants = MatrixEnchantingModule.candleInfluences.get(ord);
 					if(influencedEnchants != null) {
-					    influencer.modifyInfluencedEnchantments(world, pos, state, getStackInSlot(0), influencedEnchants);
+					    if(influencer instanceof IModifiableEnchantmentInfluencer) {
+					        IModifiableEnchantmentInfluencer modifiableInfluencer = (IModifiableEnchantmentInfluencer) influencer;
+                            influencedEnchants = modifiableInfluencer.getModifiedEnchantments(world, pos, state, getStackInSlot(0), new ArrayList<>(influencedEnchants));
+                        }
                         for(Enchantment e : influencedEnchants) {
                             int curr = influences.getOrDefault(e, 0);
                             if(curr < MatrixEnchantingModule.influenceMax)

--- a/src/main/java/vazkii/quark/api/IEnchantmentInfluencer.java
+++ b/src/main/java/vazkii/quark/api/IEnchantmentInfluencer.java
@@ -3,19 +3,25 @@ package vazkii.quark.api;
 import javax.annotation.Nullable;
 
 import net.minecraft.block.BlockState;
+import net.minecraft.enchantment.Enchantment;
 import net.minecraft.item.DyeColor;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockReader;
+
+import java.util.List;
 
 /**
  * Implement on a Block to make it influence matrix enchanting
  */
 public interface IEnchantmentInfluencer {
 
+    default void modifyInfluencedEnchantments(IBlockReader world, BlockPos pos, BlockState state, ItemStack stack, List<Enchantment> influencedEnchants) {
+    }
+
 	@Nullable DyeColor getEnchantmentInfluenceColor(IBlockReader world, BlockPos pos, BlockState state);
 	
 	default int getInfluenceStack(IBlockReader world, BlockPos pos, BlockState state) {
 		return 1;
 	}
-	
 }

--- a/src/main/java/vazkii/quark/api/IEnchantmentInfluencer.java
+++ b/src/main/java/vazkii/quark/api/IEnchantmentInfluencer.java
@@ -3,22 +3,14 @@ package vazkii.quark.api;
 import javax.annotation.Nullable;
 
 import net.minecraft.block.BlockState;
-import net.minecraft.enchantment.Enchantment;
 import net.minecraft.item.DyeColor;
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockReader;
-
-import java.util.List;
 
 /**
  * Implement on a Block to make it influence matrix enchanting
  */
 public interface IEnchantmentInfluencer {
-
-    default void modifyInfluencedEnchantments(IBlockReader world, BlockPos pos, BlockState state, ItemStack stack, List<Enchantment> influencedEnchants) {
-    }
-
 	@Nullable DyeColor getEnchantmentInfluenceColor(IBlockReader world, BlockPos pos, BlockState state);
 	
 	default int getInfluenceStack(IBlockReader world, BlockPos pos, BlockState state) {

--- a/src/main/java/vazkii/quark/api/IModifiableEnchantmentInfluencer.java
+++ b/src/main/java/vazkii/quark/api/IModifiableEnchantmentInfluencer.java
@@ -1,0 +1,17 @@
+package vazkii.quark.api;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockReader;
+
+import java.util.List;
+
+public interface IModifiableEnchantmentInfluencer extends IEnchantmentInfluencer {
+    List<Enchantment> getModifiedEnchantments(IBlockReader world, BlockPos pos, BlockState state, ItemStack stack, List<Enchantment> influencedEnchants);
+
+    default float[] getModifiedColorComponents(IBlockReader world, BlockPos pos, BlockState state, float[] colorComponents) {
+        return colorComponents;
+    }
+}


### PR DESCRIPTION
I would like to add compatibility to my [mod](https://github.com/LogicTechCorp/Reagenchant) for Matrix Enchanting, but there currently isn't a way for an enchantment influencer to define custom enchantments. This PR fixes that by allowing enchantment influencers to modify their influenced enchantments.