### PR TITLE
Use `hackilyGetCurrentClientLevelRegistryAccess` where appropriate

### DIFF
--- a/src/main/java/org/violetmoon/quark/content/client/tooltip/EnchantedBookTooltips.java
+++ b/src/main/java/org/violetmoon/quark/content/client/tooltip/EnchantedBookTooltips.java
@@ -22,13 +22,13 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.enchantment.Enchantment;
-import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.item.enchantment.EnchantmentInstance;
 
 import net.minecraft.world.item.enchantment.ItemEnchantments;
 import org.jetbrains.annotations.NotNull;
 
 import org.violetmoon.quark.base.Quark;
+import org.violetmoon.quark.base.QuarkClient;
 import org.violetmoon.quark.base.components.QuarkDataComponents;
 import org.violetmoon.quark.content.client.module.ImprovedTooltipsModule;
 import org.violetmoon.quark.content.tools.item.AncientTomeItem;
@@ -38,7 +38,6 @@ import org.violetmoon.zeta.module.IDisableable;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 public class EnchantedBookTooltips {
 
@@ -173,8 +172,7 @@ public class EnchantedBookTooltips {
 			String left = tokens[0];
 			String right = tokens[1];
 
-			//Evil getConnection
-			Minecraft.getInstance().getConnection().registryAccess().registry(Registries.ENCHANTMENT).get().getOptional(ResourceLocation.parse(left))
+			QuarkClient.ZETA_CLIENT.hackilyGetCurrentClientLevelRegistryAccess().registry(Registries.ENCHANTMENT).get().getOptional(ResourceLocation.parse(left))
 					.ifPresent(ench -> {
 						for(String itemId : right.split(",")) {
 							BuiltInRegistries.ITEM.getOptional(ResourceLocation.parse(itemId)).ifPresent(item -> additionalStacks.put(ench, new ItemStack(item)));

--- a/src/main/java/org/violetmoon/quark/content/tools/item/AncientTomeItem.java
+++ b/src/main/java/org/violetmoon/quark/content/tools/item/AncientTomeItem.java
@@ -1,7 +1,6 @@
 package org.violetmoon.quark.content.tools.item;
 
 import net.minecraft.ChatFormatting;
-import net.minecraft.client.Minecraft;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
@@ -9,12 +8,12 @@ import net.minecraft.world.item.*;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
 import org.jetbrains.annotations.NotNull;
+import org.violetmoon.quark.base.QuarkClient;
 import org.violetmoon.quark.base.components.QuarkDataComponents;
 import org.violetmoon.quark.content.tools.module.AncientTomesModule;
 import org.violetmoon.zeta.item.ZetaItem;
 import org.violetmoon.zeta.module.ZetaModule;
 import org.violetmoon.zeta.registry.CreativeTabManager;
-import org.violetmoon.zeta.util.ZetaSide;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -64,7 +63,7 @@ public class AncientTomeItem extends ZetaItem implements CreativeTabManager.Appe
 	public List<ItemStack> appendItemsToCreativeTab() {
 		List<ItemStack> items = new ArrayList<>();
 
-        Minecraft.getInstance().getConnection().registryAccess().registry(Registries.ENCHANTMENT).get().asHolderIdMap().forEach(ench -> {
+		QuarkClient.ZETA_CLIENT.hackilyGetCurrentClientLevelRegistryAccess().registry(Registries.ENCHANTMENT).get().asHolderIdMap().forEach(ench -> {
             if (!AncientTomesModule.sanityCheck || ench.value().getMaxLevel() != 1) {
                 if (!AncientTomesModule.isInitialized() && AncientTomesModule.validEnchants.contains(ench)) {
                     items.add(getEnchantedItemStack(ench));


### PR DESCRIPTION
Appears to work reliably when using https://github.com/VazkiiMods/Zeta/pull/72

Fixes an issue in my very large modpack where the logic for adding Ancient Tomes to creative tabs would throw due to `Minecraft#getConnection` returning `null`