### PR TITLE
Fix typo in the crafting recipe of stone hoes

### DIFF
--- a/src/generated/resources/data/quark/recipe/tweaks/crafting/utility/better_stone_tools/hoe.json
+++ b/src/generated/resources/data/quark/recipe/tweaks/crafting/utility/better_stone_tools/hoe.json
@@ -22,6 +22,6 @@
   ],
   "result": {
     "count": 1,
-    "id": "minecraft:stone_axe"
+    "id": "minecraft:stone_hoe"
   }
 }


### PR DESCRIPTION
There is a typo in the recipe of stone hoes which turns the output into stone axes. This PR fixes this error.