### PR TITLE
Reacharound indicator follow cursor color.  Fixes #5265

### DIFF
--- a/src/main/java/org/violetmoon/quark/content/tweaks/module/ReacharoundPlacingModule.java
+++ b/src/main/java/org/violetmoon/quark/content/tweaks/module/ReacharoundPlacingModule.java
@@ -219,6 +219,7 @@ public class ReacharoundPlacingModule extends ZetaModule {
 					boolean vertical = (currentTarget.dir.getAxis() == Axis.Y);
 					ResourceLocation texture = (vertical ? OVERLAY_VERTICAL : OVERLAY_HORIZONTAL);
 
+                    RenderSystem.enableBlend();
 					RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.ONE_MINUS_DST_COLOR, GlStateManager.DestFactor.ONE_MINUS_SRC_COLOR, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO);
 
 					matrix.pushPose();
@@ -229,7 +230,6 @@ public class ReacharoundPlacingModule extends ZetaModule {
 					matrix.popPose();
 
 					RenderSystem.defaultBlendFunc();
-
 				}
 			}
 		}


### PR DESCRIPTION
Makes reacharound indicators act like the cursor when looking at different colors, like in 1.20