### PR TITLE
[1.21.1] use ModDevGradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,8 +38,8 @@ neoForge {
     version = deps.neoforge
     
     //our accesstransformer.cfg is in the default location (meta-inf/accesstransformer.cfg)
-    //so it doesn't need to be manually configured in mdg
-    validateAccessTransformers = false //TODO turn this back on  LOL!!
+    //so its path doesn't need to be manually configured in mdg
+    validateAccessTransformers = true
     
     mods {
         quark {

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -6,14 +6,11 @@ public net.minecraft.client.gui.screens.recipebook.RecipeBookComponent searchBox
 public net.minecraft.client.gui.screens.recipebook.RecipeBookComponent recipeBookPage # recipeBookPage
 public net.minecraft.client.gui.screens.recipebook.RecipeBookComponent checkSearchStringUpdate()V # checkSearchStringUpdate
 public net.minecraft.client.gui.screens.recipebook.RecipeBookPage recipeCollections # recipeCollections
-public net.minecraft.client.multiplayer.PlayerInfo f_105299_ # playerTextures
-public net.minecraft.client.renderer.LevelRenderer f_109410_ # mapSoundPositions
 public net.minecraft.client.renderer.entity.LivingEntityRenderer layers # layers
 public net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer getArmorModel(Lnet/minecraft/world/entity/EquipmentSlot;)Lnet/minecraft/client/model/HumanoidModel; # getArmorModel
 public net.minecraft.world.entity.LivingEntity attackStrengthTicker # attackStrengthTicker
 public net.minecraft.util.random.Weight <init>(I)V # <init>
 public net.minecraft.world.entity.LivingEntity jumping # jumping
-public net.minecraft.world.entity.LivingEntity f_20922_ # ticksSinceLastSwing
 public net.minecraft.world.entity.ai.goal.TemptGoal items # items
 public net.minecraft.world.entity.ai.gossip.GossipContainer gossips # gossips
 public net.minecraft.world.entity.ai.gossip.GossipContainer$EntityGossips
@@ -21,48 +18,24 @@ public net.minecraft.world.entity.animal.horse.AbstractHorse createInventory()V 
 public net.minecraft.world.entity.item.FallingBlockEntity blockState # blockState
 public net.minecraft.world.entity.monster.ZombieVillager gossips # gossips
 public-f net.minecraft.world.entity.player.Player inventoryMenu # inventoryMenu
-public net.minecraft.world.entity.projectile.ThrownTrident m_7941_()Lnet/minecraft/world/item/ItemStack; # getArrowStack
 public-f net.minecraft.world.inventory.AbstractContainerMenu containerId # containerId
 public-f net.minecraft.world.inventory.Slot y # y
-public-f net.minecraft.world.item.Item f_41378_ # containerItem
-public net.minecraft.world.level.block.ButtonBlock m_51115_()I # tickRate
-public net.minecraft.world.level.block.DispenserBlock f_52661_ # DISPENSE_BEHAVIOR_REGISTRY
 public net.minecraft.world.level.block.entity.AbstractFurnaceBlockEntity cookingProgress # cookingProgress
 public net.minecraft.world.level.block.entity.AbstractFurnaceBlockEntity cookingTotalTime # cookingTotalTime
 public net.minecraft.world.level.block.entity.BeaconBlockEntity checkingBeamSections # checkingBeamSections # beamSections
 public net.minecraft.world.level.block.entity.BeaconBlockEntity lastCheckY # lastCheckY
 public net.minecraft.world.level.block.entity.BeaconBlockEntity$BeaconBeamSection height # height
-public net.minecraft.world.level.block.entity.BeaconBlockEntity height
-public net.minecraft.world.level.block.entity.BlockEntity f_58856_ # cachedBlockState
-public net.minecraft.world.level.block.entity.SignBlockEntity f_59720_ # signText
-public net.minecraft.world.level.block.entity.SignBlockEntity f_59721_ # isEditable
-public-f net.minecraft.world.level.levelgen.StructureSettings f_189361_ #configuredStructures
-public-f net.minecraft.world.level.levelgen.StructureSettings f_64580_ # DEFAULTS
-public-f net.minecraft.world.level.levelgen.StructureSettings f_64582_ # structureConfig
 public net.minecraft.world.level.block.VineBlock canSupportAtFace(Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/Direction;)Z # canSupportAtFace
-public net.minecraft.data.worldgen.biome.OverworldBiomes m_194861_(Lnet/minecraft/world/level/biome/Biome$Precipitation;Lnet/minecraft/world/level/biome/Biome$BiomeCategory;FFLnet/minecraft/world/level/biome/MobSpawnSettings$Builder;Lnet/minecraft/world/level/biome/BiomeGenerationSettings$Builder;Lnet/minecraft/sounds/Music;)Lnet/minecraft/world/level/biome/Biome; # biome
-public net.minecraft.data.worldgen.biome.OverworldBiomes m_194851_(Lnet/minecraft/world/level/biome/Biome$Precipitation;Lnet/minecraft/world/level/biome/Biome$BiomeCategory;FFIILnet/minecraft/world/level/biome/MobSpawnSettings$Builder;Lnet/minecraft/world/level/biome/BiomeGenerationSettings$Builder;Lnet/minecraft/sounds/Music;)Lnet/minecraft/world/level/biome/Biome; # biome
 public-f net.minecraft.world.level.block.entity.BlockEntityType validBlocks # validBlocks
 public-f net.minecraft.world.level.levelgen.feature.configurations.TreeConfiguration trunkProvider # trunkProvider
-public net.minecraft.client.resources.model.ModelBakery f_119243_ # resourceManager
 public net.minecraft.client.model.ChickenModel leftLeg # leftLeg
 public net.minecraft.client.model.ChickenModel rightLeg # rightLeg
-public net.minecraft.world.entity.Entity f_19817_ # isInsidePortal
 public net.minecraft.world.entity.npc.VillagerTrades$EnchantBookForEmeralds
-public net.minecraft.world.inventory.MerchantMenu m_40060_(ILnet/minecraft/world/item/ItemStack;)V # moveFromInventoryToPaymentSlot
-public net.minecraft.world.item.trading.MerchantOffer m_45365_(Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/item/ItemStack;)Z # isRequiredItem
-public net.minecraft.world.item.Item m_41435_(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/level/ClipContext$Fluid;)Lnet/minecraft/world/phys/BlockHitResult; # getPlayerPOVHitResult
 public net.minecraft.world.entity.projectile.AbstractArrow pickupItemStack # pickupItemStack
-public net.minecraft.world.item.CompassItem m_40727_(Lnet/minecraft/nbt/CompoundTag;)Ljava/util/Optional; # getLodestoneDimension
-public net.minecraft.data.worldgen.biome.OverworldBiomes m_236663_(Lnet/minecraft/world/level/biome/Biome$Precipitation;FFLnet/minecraft/world/level/biome/MobSpawnSettings$Builder;Lnet/minecraft/world/level/biome/BiomeGenerationSettings$Builder;Lnet/minecraft/sounds/Music;)Lnet/minecraft/world/level/biome/Biome; # biome
-public net.minecraft.data.worldgen.biome.OverworldBiomes m_236654_(Lnet/minecraft/world/level/biome/Biome$Precipitation;FFIILnet/minecraft/world/level/biome/MobSpawnSettings$Builder;Lnet/minecraft/world/level/biome/BiomeGenerationSettings$Builder;Lnet/minecraft/sounds/Music;)Lnet/minecraft/world/level/biome/Biome; # biome
 public net.minecraft.world.entity.animal.frog.Tadpole setAge(I)V # setAge
-public net.minecraft.world.entity.animal.TropicalFish m_30064_(I)I # getPatternVariant
-public net.minecraft.world.item.context.BlockPlaceContext f_43628_ # replaceClicked
-public net.minecraft.client.gui.Gui f_279580_ # GUI_ICONS_LOCATION
 public net.minecraft.world.level.block.state.BlockBehaviour$BlockStateBase mapColor # mapColor
 public net.minecraft.core.RegistrySetBuilder$BuildState
-public net.minecraft.client.resources.model.ModelManager$ReloadState
+public net.minecraft.core.RegistrySetBuilder$BuildState <init>(Lnet/minecraft/core/RegistrySetBuilder$UniversalOwner;Lnet/minecraft/core/RegistrySetBuilder$UniversalLookup;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;)V # (must publicize the constructor of BuildState if the record is to be made public)
 public net.minecraft.world.entity.npc.VillagerTrades$ItemsForEmeralds
 public net.minecraft.world.entity.npc.VillagerTrades$ItemsAndEmeraldsToItems
 public net.minecraft.world.entity.npc.VillagerTrades$EmeraldForItems


### PR DESCRIPTION
Also deletes a bunch of ATs because MDG's AT validation exposed them as invalid

things TODO:

* doublecheck publishing still works as expected
* doublecheck datagen still works as expected
* readd that `tasks.jarJar.configure` block iff it is necessary

and some housekeeping while we're on the subject of the buildscript:

* reorder the file? is there a standard order for gradle files? lol
* doublecheck that the global system properties are working as expected to configure logging levels
* add `includeGroup`s to all mavens
* address that "Replace the following line when spotless is setup" comment