### PR TITLE
Fix corundum not receiving random ticks

### DIFF
--- a/src/main/java/org/violetmoon/quark/content/world/block/CorundumBlock.java
+++ b/src/main/java/org/violetmoon/quark/content/world/block/CorundumBlock.java
@@ -65,7 +65,7 @@ public class CorundumBlock extends ZetaGlassBlock {
 	}
 
 	@Override
-	public void tick(@NotNull BlockState state, @NotNull ServerLevel worldIn, @NotNull BlockPos pos, @NotNull RandomSource random) {
+	protected void randomTick(@NotNull BlockState state, @NotNull ServerLevel worldIn, @NotNull BlockPos pos, @NotNull RandomSource random) {
 		if(canGrow(worldIn, pos) && random.nextInt(CorundumModule.caveCrystalGrowthChance) == 0) {
 			BlockState down = worldIn.getBlockState(pos.below());
 			BlockPos up = pos.above();


### PR DESCRIPTION
Closes #5415.

I've searched for uses of `BlockBehaviour.Properties randomTicks()` and found no other blocks that implemented `tick()` and would've needed the same fix.