### PR TITLE
Fix invalid wraith sounds

### DIFF
--- a/src/main/java/org/violetmoon/quark/content/mobs/module/WraithModule.java
+++ b/src/main/java/org/violetmoon/quark/content/mobs/module/WraithModule.java
@@ -58,13 +58,13 @@ public class WraithModule extends ZetaModule {
 			"entity.skeleton.ambient|entity.skeleton.hurt|entity.skeleton.death",
 			"entity.spider.ambient|entity.spider.hurt|entity.spider.death",
 			"|entity.creeper.hurt|entity.creeper.death",
-			"entity.endermen.ambient|entity.endermen.hurt|entity.endermen.death",
-			"entity.zombie_pig.ambient|entity.zombie_pig.hurt|entity.zombie_pig.death",
+			"entity.enderman.ambient|entity.enderman.hurt|entity.enderman.death",
+			"entity.zombified_piglin.ambient|entity.zombified_piglin.hurt|entity.zombified_piglin.death",
 			"entity.witch.ambient|entity.witch.hurt|entity.witch.death",
 			"entity.blaze.ambient|entity.blaze.hurt|entity.blaze.death",
 			"entity.llama.ambient|entity.llama.hurt|entity.llama.death",
 			"|quark:entity.stoneling.cry|quark:entity.stoneling.die",
-			"quark:entity.frog.idle|quark:entity.frog.hurt|quark:entity.frog.die"
+			"minecraft:entity.frog.ambient|minecraft:entity.frog.hurt|minecraft:entity.frog.death"
 	);
 
 	@Config


### PR DESCRIPTION
This part of the code was unchanged since 1.12, and since then some sounds ids were changed, resulting in some wraiths having no sounds (except their footsteps).
- `endermen` was changed to `enderman`
- `zombie_pig` was changed to `zombified_piglin`
- Frogs were added to the game and removed from quark, so I replaced Quark's frog sounds by Minecraft's frog sounds. (Tell me if you wish to remove these sounds from the wraith entirely).

On a related note, since I could not find a consistent pattern to which sounds were used by wraiths, I did not open a suggestion to add new mobs sounds. Please tell me if this is something you wish to pursue, and how I could discuss the details.
