### PR TITLE
Fix trowel

### DIFF
--- a/src/main/java/org/violetmoon/quark/content/management/module/AutomaticToolRestockModule.java
+++ b/src/main/java/org/violetmoon/quark/content/management/module/AutomaticToolRestockModule.java
@@ -84,7 +84,7 @@ public class AutomaticToolRestockModule extends ZetaModule {
 	private boolean unstackablesOnly = false;
 
 	@Config(description = "Any items you place in this list will be ignored by the restock feature")
-	private List<String> ignoredItems = Lists.newArrayList("botania:exchange_rod", "botania:dirt_rod", "botania:skydirt_rod", "botania:cobble_rod");
+	private List<String> ignoredItems = Lists.newArrayList("quark:trowel", "botania:exchange_rod", "botania:dirt_rod", "botania:skydirt_rod", "botania:cobble_rod");
 
 	private final Object MUTEX = new Object();
 

--- a/src/main/java/org/violetmoon/quark/content/tools/item/TrowelItem.java
+++ b/src/main/java/org/violetmoon/quark/content/tools/item/TrowelItem.java
@@ -70,7 +70,7 @@ public class TrowelItem extends ZetaItem implements IUsageTickerOverride {
 		inventory.setItem(targetSlot, newHandItem);
 
 		if (result.consumesAction()) {
-			trowel.set(QuarkDataComponents.LAST_STACK, new ItemWrapperComponent(toPlaceStack));
+			trowel.set(QuarkDataComponents.LAST_STACK, new ItemWrapperComponent(toPlaceStack.copy()));
 
 			if (TrowelModule.maxDamage > 0)
 				MiscUtil.damageStack(context.getItemInHand(), 1, player, hand == InteractionHand.MAIN_HAND ? EquipmentSlot.MAINHAND : EquipmentSlot.OFFHAND);


### PR DESCRIPTION
Use a copy of the itemstack for the usageticker instead of just a reference, so it doesn't become air when the items are not longer in the slot.

Also adds the trowel to the items ignored by the automatic tool restock.. this means if the trowel is given durability; For future reference, I tested this in 1.20 and with durability, the trowel does 2 things with ATR, first it swaps everytime it changes dura for some reason, second it does NOT restock correctly when it breaks, it instead, swaps to the block, so it needs to be blacklisted either way.