### PR TITLE
Make stoneling (tuff variant) use the real polished tuff block.

### DIFF
--- a/src/main/java/org/violetmoon/quark/content/mobs/entity/Stoneling.java
+++ b/src/main/java/org/violetmoon/quark/content/mobs/entity/Stoneling.java
@@ -491,7 +491,7 @@ public class Stoneling extends PathfinderMob {
 		SHALE("shale", shaleBlock, polishedBlocks.get(shaleBlock)),
 		JASPER("jasper", jasperBlock, polishedBlocks.get(jasperBlock)),
 		DEEPSLATE("deepslate", Blocks.DEEPSLATE, Blocks.POLISHED_DEEPSLATE),
-		TUFF("tuff", Blocks.TUFF, polishedBlocks.get(Blocks.TUFF)),
+		TUFF("tuff", Blocks.TUFF, Blocks.POLISHED_TUFF),
 		DRIPSTONE("dripstone", Blocks.DRIPSTONE_BLOCK, polishedBlocks.get(Blocks.DRIPSTONE_BLOCK));
 
 		private final ResourceLocation texture;


### PR DESCRIPTION
How this happened: Quark backports. Quark used to have the polished tuff block, so the stoneling tuff variant was looking for the quark polished tuff block (that doesn't exist anymore, therefore getting a null) instead of the vanilla one.
It did give a NPE but I couldn't make this crash neither the client nor the server, BUT, not having the correct polished block meant you couldn't use it to give my boy this awesome look

<img width="369" height="300" alt="image" src="https://github.com/user-attachments/assets/05d445de-04e5-4eed-b719-4d9be47c5c8d" />

So this fixes that important problem.