### PR TITLE
Use getHolder for book enchantments

### DIFF
--- a/src/main/java/org/violetmoon/quark/addons/oddities/util/InfluenceLocations.java
+++ b/src/main/java/org/violetmoon/quark/addons/oddities/util/InfluenceLocations.java
@@ -1,9 +1,11 @@
 package org.violetmoon.quark.addons.oddities.util;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.level.Level;
 import org.violetmoon.quark.base.Quark;
 
 import java.util.ArrayList;
@@ -15,12 +17,12 @@ import java.util.List;
  * @param dampen Dampened Enchants
  */
 public record InfluenceLocations(List<ResourceLocation> boost, List<ResourceLocation> dampen) {
-    public Influence toInfluence() {
+    public Influence toInfluence(Level level) {
         List<Holder<Enchantment>> boostedEnchantments = new ArrayList<>();
         List<Holder<Enchantment>> dampenedEnchantments = new ArrayList<>();
 
         for (ResourceLocation location : boost) {
-            Holder<Enchantment> ench = Holder.direct(Quark.proxy.hackilyGetCurrentClientLevelRegistryAccess().registry(Registries.ENCHANTMENT).get().get(location));
+            Holder<Enchantment> ench = level.registryAccess().registry(Registries.ENCHANTMENT).get().getHolder(location).orElseThrow();
             if (ench != null) {
                 boostedEnchantments.add(ench);
             } else {
@@ -29,7 +31,7 @@ public record InfluenceLocations(List<ResourceLocation> boost, List<ResourceLoca
         }
 
         for (ResourceLocation location : dampen) {
-            Holder<Enchantment> ench = Holder.direct(Quark.proxy.hackilyGetCurrentClientLevelRegistryAccess().registry(Registries.ENCHANTMENT).get().get(location));
+            Holder<Enchantment> ench = level.registryAccess().registry(Registries.ENCHANTMENT).get().getHolder(location).orElseThrow();
             if (ench != null) {
                 dampenedEnchantments.add(ench);
             } else {

--- a/src/main/java/org/violetmoon/quark/integration/jei/InfluenceEntry.java
+++ b/src/main/java/org/violetmoon/quark/integration/jei/InfluenceEntry.java
@@ -2,6 +2,7 @@ package org.violetmoon.quark.integration.jei;
 
 import mezz.jei.api.recipe.category.extensions.IRecipeCategoryExtension;
 import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.inventory.AnvilScreen;
 import net.minecraft.core.Holder;
 import net.minecraft.core.NonNullList;
@@ -15,35 +16,42 @@ import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.item.enchantment.EnchantmentInstance;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.AnvilBlock;
 import net.minecraft.world.level.block.Block;
 import org.violetmoon.quark.addons.oddities.util.Influence;
+import org.violetmoon.quark.addons.oddities.util.InfluenceLocations;
 import org.violetmoon.quark.base.components.QuarkDataComponents;
 import org.violetmoon.quark.content.tools.base.RuneColor;
 import org.violetmoon.quark.content.tools.module.ColorRunesModule;
 
 import java.util.List;
+import java.util.Optional;
 
 public class InfluenceEntry implements IRecipeCategoryExtension {
 
 	private final ItemStack candleStack;
-	private final ItemStack boost;
-	private final ItemStack dampen;
-	private final List<ItemStack> associatedBooks;
+	private final InfluenceLocations influenceLocations;
+	private Optional<ItemStack> boost;
+	private Optional<ItemStack> dampen;
+	private Optional<List<ItemStack>> associatedBooks;
 
-	public InfluenceEntry(Block candle, Influence influence) {
+	public InfluenceEntry(Block candle, InfluenceLocations influenceLocations) {
 		this.candleStack = new ItemStack(candle);
-		this.boost = getEnchantedBook(influence.boost(), RuneColor.GREEN, ChatFormatting.GREEN, "quark.jei.boost_influence");
-		this.dampen = getEnchantedBook(influence.dampen(), RuneColor.RED, ChatFormatting.RED, "quark.jei.dampen_influence");
-		this.associatedBooks = buildAssociatedBooks(influence);
+		this.influenceLocations = influenceLocations;
+		this.boost = Optional.empty();
+		this.dampen = Optional.empty();
+		this.associatedBooks = Optional.empty();
 	}
 
 	public ItemStack getBoostBook() {
-		return this.boost;
+		initializeBooks();
+		return this.boost.get();
 	}
 
 	public ItemStack getDampenBook() {
-		return this.dampen;
+		initializeBooks();
+		return this.dampen.get();
 	}
 
 	public ItemStack getCandleStack() {
@@ -51,7 +59,20 @@ public class InfluenceEntry implements IRecipeCategoryExtension {
 	}
 
 	public List<ItemStack> getAssociatedBooks() {
-		return this.associatedBooks;
+		initializeBooks();
+		return this.associatedBooks.get();
+	}
+
+	private void initializeBooks() {
+		if (this.boost.isEmpty() || this.dampen.isEmpty() || this.associatedBooks.isEmpty()) {
+			Level level = Minecraft.getInstance().level;
+			if (level != null) {
+				Influence influence = this.influenceLocations.toInfluence(level);
+				this.boost = Optional.of(getEnchantedBook(influence.boost(), RuneColor.GREEN, ChatFormatting.GREEN, "quark.jei.boost_influence"));
+				this.dampen = Optional.of(getEnchantedBook(influence.dampen(), RuneColor.RED, ChatFormatting.RED, "quark.jei.dampen_influence"));
+				this.associatedBooks = Optional.of(buildAssociatedBooks(influence));
+			}
+		}
 	}
 
 	private static ItemStack getEnchantedBook(List<Holder<Enchantment>> enchantments, RuneColor runeColor, ChatFormatting chatColor, String locKey) {
@@ -94,6 +115,6 @@ public class InfluenceEntry implements IRecipeCategoryExtension {
 	}
 
 	public boolean hasAny() {
-		return !boost.isEmpty() || !dampen.isEmpty();
+		return !influenceLocations.boost().isEmpty() || !influenceLocations.dampen().isEmpty();
 	}
 }

--- a/src/main/java/org/violetmoon/quark/integration/jei/QuarkJeiPlugin.java
+++ b/src/main/java/org/violetmoon/quark/integration/jei/QuarkJeiPlugin.java
@@ -40,6 +40,7 @@ import org.violetmoon.quark.addons.oddities.client.screen.BackpackInventoryScree
 import org.violetmoon.quark.addons.oddities.client.screen.CrateScreen;
 import org.violetmoon.quark.addons.oddities.module.MatrixEnchantingModule;
 import org.violetmoon.quark.addons.oddities.util.Influence;
+import org.violetmoon.quark.addons.oddities.util.InfluenceLocations;
 import org.violetmoon.quark.base.Quark;
 import org.violetmoon.quark.base.components.QuarkDataComponents;
 import org.violetmoon.quark.content.building.module.VariantFurnacesModule;
@@ -189,17 +190,17 @@ public class QuarkJeiPlugin implements IModPlugin {
         registration.addRecipes(INFLUENCING,
                 Arrays.stream(DyeColor.values()).map(color -> {
                     Block candle = MatrixEnchantingTableBlockEntity.CANDLES.get(color.getId());
-                    Influence influence = MatrixEnchantingModule.candleInfluences.get(color).toInfluence();
+                    InfluenceLocations influenceLocations = MatrixEnchantingModule.candleInfluences.get(color);
 
-                    return new InfluenceEntry(candle, influence);
+                    return new InfluenceEntry(candle, influenceLocations);
                 }).filter(InfluenceEntry::hasAny).collect(Collectors.toList()));
 
         registration.addRecipes(INFLUENCING,
                 MatrixEnchantingModule.customInfluences.entrySet().stream().map(entry -> {
                     Block block = entry.getKey().getBlock();
-                    Influence influence = entry.getValue().influence().toInfluence();
+                    InfluenceLocations influenceLocations = entry.getValue().influence();
 
-                    return new InfluenceEntry(block, influence);
+                    return new InfluenceEntry(block, influenceLocations);
                 }).filter(InfluenceEntry::hasAny).collect(Collectors.toList()));
     }
 


### PR DESCRIPTION
Makes InfluenceEntry have an InfluenceLocations field instead of an Influence, and keeps its enchanted book stacks as empty optionals until setRecipe is called. This way, it can use the level's registry access instead of the hacky proxy, and therefore use the enchantment registry's own reference holders for the enchantments, rather than creating Direct holders for them. This closes #5556, and also solves another small unreported issue I've noticed wherein pressing the recipe-lookup or uses-lookup key on an enchanted book doesn't bring up the relevant influencing recipes.