### PR TITLE
Configurable items dropped when punching Totem of Holding

### DIFF
--- a/src/main/java/org/violetmoon/quark/addons/oddities/entity/TotemOfHoldingEntity.java
+++ b/src/main/java/org/violetmoon/quark/addons/oddities/entity/TotemOfHoldingEntity.java
@@ -36,7 +36,7 @@ import java.util.List;
 
 /**
  * @author WireSegal
- * Created at 1:34 PM on 3/30/20.
+ *         Created at 1:34 PM on 3/30/20.
  */
 public class TotemOfHoldingEntity extends Entity {
     private static final String TAG_ITEMS = "storedItems";
@@ -75,9 +75,9 @@ public class TotemOfHoldingEntity extends Entity {
     }
 
     private Player getOwnerEntity() {
-        for (Player player : level().players()) {
+        for(Player player : level().players()) {
             String uuid = player.getUUID().toString();
-            if (uuid.equals(owner))
+            if(uuid.equals(owner))
                 return player;
         }
         return null;
@@ -145,18 +145,18 @@ public class TotemOfHoldingEntity extends Entity {
     @Override
     public void tick() {
         super.tick();
-        if (!isAlive()) return;
+        if(!isAlive()) return;
 
         if (TotemOfHoldingModule.darkSoulsMode) {
             Player owner = getOwnerEntity();
-            if (owner != null && !level().isClientSide) {
+            if(owner != null && !level().isClientSide) {
                 String ownerTotem = TotemOfHoldingModule.getTotemUUID(owner);
-                if (!getUUID().toString().equals(ownerTotem))
+                if(!getUUID().toString().equals(ownerTotem))
                     dropEverythingAndDie();
             }
         }
 
-        if (storedItems.isEmpty() && !level().isClientSide)
+        if(storedItems.isEmpty() && !level().isClientSide)
             entityData.set(DYING, true);
 
         if (isDying()) {
@@ -169,14 +169,14 @@ public class TotemOfHoldingEntity extends Entity {
     }
 
     private void dropEverythingAndDie() {
-        if (!TotemOfHoldingModule.destroyLostItems)
-            for (ItemStack storedItem : storedItems)
+        if(!TotemOfHoldingModule.destroyLostItems)
+            for(ItemStack storedItem : storedItems)
                 spawnAtLocation(storedItem, 0);
 
         storedItems.clear();
         equipedCurios.clear();
         Player owner = getOwnerEntity();
-        if (owner != null && !level().isClientSide) {
+        if(owner != null && !level().isClientSide) {
             owner.sendSystemMessage(Component.translatable("quark.misc.totem_darksouls").withStyle(ChatFormatting.BOLD));
         }
 
@@ -198,7 +198,7 @@ public class TotemOfHoldingEntity extends Entity {
         storedItems = new LinkedList<>();
         equipedCurios = new LinkedList<>();
 
-        for (int i = 0; i < list.size(); i++) {
+        for(int i = 0; i < list.size(); i++) {
             CompoundTag cmp = list.getCompound(i);
             ItemStack stack = ItemStack.parseOptional(level().registryAccess(), cmp);
             storedItems.add(stack);
@@ -221,7 +221,7 @@ public class TotemOfHoldingEntity extends Entity {
         ListTag list = new ListTag();
         ListTag curiosList = new ListTag();
 
-        for (ItemStack stack : storedItems) {
+        for(ItemStack stack : storedItems) {
             list.add(stack.save(level().registryAccess()));
         }
 
@@ -234,7 +234,7 @@ public class TotemOfHoldingEntity extends Entity {
         compound.put(TAG_ITEMS, list);
         compound.put(TAG_CURIOS, curiosList);
         compound.putBoolean(TAG_DYING, isDying());
-        if (owner != null)
+        if(owner != null)
             compound.putString(TAG_OWNER, owner);
     }
 

--- a/src/main/java/org/violetmoon/quark/addons/oddities/entity/TotemOfHoldingEntity.java
+++ b/src/main/java/org/violetmoon/quark/addons/oddities/entity/TotemOfHoldingEntity.java
@@ -14,6 +14,7 @@ import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.server.level.ServerEntity;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.EquipmentSlot;
@@ -35,203 +36,211 @@ import java.util.List;
 
 /**
  * @author WireSegal
- *         Created at 1:34 PM on 3/30/20.
+ * Created at 1:34 PM on 3/30/20.
  */
 public class TotemOfHoldingEntity extends Entity {
-	private static final String TAG_ITEMS = "storedItems";
-	private static final String TAG_CURIOS = "curiosList";
-	private static final String TAG_DYING = "dying";
-	private static final String TAG_OWNER = "owner";
+    private static final String TAG_ITEMS = "storedItems";
+    private static final String TAG_CURIOS = "curiosList";
+    private static final String TAG_DYING = "dying";
+    private static final String TAG_OWNER = "owner";
 
-	private static final EntityDataAccessor<Boolean> DYING = SynchedEntityData.defineId(TotemOfHoldingEntity.class, EntityDataSerializers.BOOLEAN);
+    private static final EntityDataAccessor<Boolean> DYING = SynchedEntityData.defineId(TotemOfHoldingEntity.class, EntityDataSerializers.BOOLEAN);
 
-	public static final int DEATH_TIME = 40;
+    public static final int DEATH_TIME = 40;
 
-	private int deathTicks = 0;
-	private String owner;
-	private List<ItemStack> storedItems = new LinkedList<>();
-	private List<ItemStack> equipedCurios = new LinkedList<>();
+    private int deathTicks = 0;
+    private String owner;
+    private List<ItemStack> storedItems = new LinkedList<>();
+    private List<ItemStack> equipedCurios = new LinkedList<>();
 
-	public TotemOfHoldingEntity(EntityType<? extends TotemOfHoldingEntity> entityType, Level worldIn) {
-		super(entityType, worldIn);
-	}
+    public TotemOfHoldingEntity(EntityType<? extends TotemOfHoldingEntity> entityType, Level worldIn) {
+        super(entityType, worldIn);
+    }
 
-	@Override
-	protected void defineSynchedData(SynchedEntityData.Builder builder) {
+    @Override
+    protected void defineSynchedData(SynchedEntityData.Builder builder) {
         builder.define(DYING, false);
-	}
+    }
 
-	public void addItem(ItemStack stack) {
-		storedItems.add(stack);
-	}
+    public void addItem(ItemStack stack) {
+        storedItems.add(stack);
+    }
 
-	public void addCurios(ItemStack stack) {
-		equipedCurios.add(stack);
-	}
+    public void addCurios(ItemStack stack) {
+        equipedCurios.add(stack);
+    }
 
-	public void setOwner(Player player) {
-		owner = player.getUUID().toString();
-	}
+    public void setOwner(Player player) {
+        owner = player.getUUID().toString();
+    }
 
-	private Player getOwnerEntity() {
-		for(Player player : level().players()) {
-			String uuid = player.getUUID().toString();
-			if(uuid.equals(owner))
-				return player;
-		}
-		return null;
-	}
+    private Player getOwnerEntity() {
+        for (Player player : level().players()) {
+            String uuid = player.getUUID().toString();
+            if (uuid.equals(owner))
+                return player;
+        }
+        return null;
+    }
 
-	@Override
-	public boolean skipAttackInteraction(@NotNull Entity entity) {
-		if (level() instanceof ServerLevel serverLevel && entity instanceof Player player) {
-			if (!TotemOfHoldingModule.allowAnyoneToCollect && !player.hasInfiniteMaterials() && entity != getOwnerEntity()) return false;
+    @Override
+    public boolean skipAttackInteraction(@NotNull Entity entity) {
+        if (level() instanceof ServerLevel serverLevel && entity instanceof Player player) {
+            if (!TotemOfHoldingModule.allowAnyoneToCollect && !player.hasInfiniteMaterials() && entity != getOwnerEntity())
+                return false;
 
-			int drops = Math.min(storedItems.size(), 3 + level().random.nextInt(4));
+            int drops = storedItems.size();
 
-			for (int i = 0; i < drops; i++) {
-				ItemStack stack = storedItems.removeFirst();
+            int max = TotemOfHoldingModule.maxDropsRecoveredPerHit;
+            int min = TotemOfHoldingModule.minDropsRecoveredPerHit;
+            if (max > 0 && min >= 0) {
+                max = Math.max(min, max);
+                drops = Math.min(storedItems.size(), Mth.nextInt(level().random, min, max));
+            }
 
-				if (stack.getItem() instanceof ArmorItem armor) {
-					EquipmentSlot slot = armor.getEquipmentSlot();
-					ItemStack curr = player.getItemBySlot(slot);
+            for (int i = 0; i < drops; i++) {
+                ItemStack stack = storedItems.removeFirst();
 
-					if (curr.isEmpty()) {
-						player.setItemSlot(slot, stack);
-						stack = null;
-					} else if (!(curr.getItem() instanceof BackpackItem)
-							&& !(EnchantmentHelper.getTagEnchantmentLevel(serverLevel.registryAccess().lookupOrThrow(Registries.ENCHANTMENT).getOrThrow(Enchantments.BINDING_CURSE), curr) > 0)
-							&& EnchantmentHelper.getTagEnchantmentLevel(serverLevel.registryAccess().lookupOrThrow(Registries.ENCHANTMENT).getOrThrow(Enchantments.BINDING_CURSE), stack) > 0) {
-						player.setItemSlot(slot, stack);
-						stack = curr;
-					}
-				} else if (stack.getItem() instanceof ShieldItem) {
-					ItemStack curr = player.getItemBySlot(EquipmentSlot.OFFHAND);
+                if (stack.getItem() instanceof ArmorItem armor) {
+                    EquipmentSlot slot = armor.getEquipmentSlot();
+                    ItemStack curr = player.getItemBySlot(slot);
 
-					if (curr.isEmpty()) {
-						player.setItemSlot(EquipmentSlot.OFFHAND, stack);
-						stack = null;
-					}
+                    if (curr.isEmpty()) {
+                        player.setItemSlot(slot, stack);
+                        stack = null;
+                    } else if (!(curr.getItem() instanceof BackpackItem)
+                            && !(EnchantmentHelper.getTagEnchantmentLevel(serverLevel.registryAccess().lookupOrThrow(Registries.ENCHANTMENT).getOrThrow(Enchantments.BINDING_CURSE), curr) > 0)
+                            && EnchantmentHelper.getTagEnchantmentLevel(serverLevel.registryAccess().lookupOrThrow(Registries.ENCHANTMENT).getOrThrow(Enchantments.BINDING_CURSE), stack) > 0) {
+                        player.setItemSlot(slot, stack);
+                        stack = curr;
+                    }
+                } else if (stack.getItem() instanceof ShieldItem) {
+                    ItemStack curr = player.getItemBySlot(EquipmentSlot.OFFHAND);
 
-				} else if (Quark.ZETA.isModLoaded("curios")) {
-					stack = TotemOfHoldingCuriosCompat.equipCurios(player, equipedCurios, stack);
-				}
+                    if (curr.isEmpty()) {
+                        player.setItemSlot(EquipmentSlot.OFFHAND, stack);
+                        stack = null;
+                    }
 
-				if (stack != null && !player.addItem(stack)) {
-					spawnAtLocation(stack, 0);
-				}
-			}
+                } else if (Quark.ZETA.isModLoaded("curios")) {
+                    stack = TotemOfHoldingCuriosCompat.equipCurios(player, equipedCurios, stack);
+                }
 
-			serverLevel.sendParticles(ParticleTypes.DAMAGE_INDICATOR, getX(), getY() + 0.5, getZ(), drops, 0.1, 0.5, 0.1, 0);
-			serverLevel.sendParticles(ParticleTypes.ENCHANTED_HIT, getX(), getY() + 0.5, getZ(), drops, 0.4, 0.5, 0.4, 0);
-		}
-		return false;
-	}
+                if (stack != null && !player.addItem(stack)) {
+                    spawnAtLocation(stack, 0);
+                }
+            }
 
-	@Override
-	public boolean isPickable() {
-		return true;
-	}
+            serverLevel.sendParticles(ParticleTypes.DAMAGE_INDICATOR, getX(), getY() + 0.5, getZ(), drops, 0.1, 0.5, 0.1, 0);
+            serverLevel.sendParticles(ParticleTypes.ENCHANTED_HIT, getX(), getY() + 0.5, getZ(), drops, 0.4, 0.5, 0.4, 0);
+        }
+        return false;
+    }
 
-	@Override
-	public void tick() {
-		super.tick();
-		if(!isAlive()) return;
+    @Override
+    public boolean isPickable() {
+        return true;
+    }
 
-		if (TotemOfHoldingModule.darkSoulsMode) {
-			Player owner = getOwnerEntity();
-			if(owner != null && !level().isClientSide) {
-				String ownerTotem = TotemOfHoldingModule.getTotemUUID(owner);
-				if(!getUUID().toString().equals(ownerTotem))
-					dropEverythingAndDie();
-			}
-		}
+    @Override
+    public void tick() {
+        super.tick();
+        if (!isAlive()) return;
 
-		if(storedItems.isEmpty() && !level().isClientSide)
-			entityData.set(DYING, true);
+        if (TotemOfHoldingModule.darkSoulsMode) {
+            Player owner = getOwnerEntity();
+            if (owner != null && !level().isClientSide) {
+                String ownerTotem = TotemOfHoldingModule.getTotemUUID(owner);
+                if (!getUUID().toString().equals(ownerTotem))
+                    dropEverythingAndDie();
+            }
+        }
 
-		if (isDying()) {
-			if (deathTicks > DEATH_TIME)
-				discard();
-			else
-				deathTicks++;
-		} else if (level().isClientSide)
-			level().addParticle(ParticleTypes.PORTAL, getX(), getY() + (this.random.nextDouble() - 0.5) * 0.2, getZ(), Math.random() - 0.5, Math.random() - 0.5, Math.random() - 0.5);
-	}
+        if (storedItems.isEmpty() && !level().isClientSide)
+            entityData.set(DYING, true);
 
-	private void dropEverythingAndDie() {
-		if(!TotemOfHoldingModule.destroyLostItems)
-			for(ItemStack storedItem : storedItems)
-				spawnAtLocation(storedItem, 0);
+        if (isDying()) {
+            if (deathTicks > DEATH_TIME)
+                discard();
+            else
+                deathTicks++;
+        } else if (level().isClientSide)
+            level().addParticle(ParticleTypes.PORTAL, getX(), getY() + (this.random.nextDouble() - 0.5) * 0.2, getZ(), Math.random() - 0.5, Math.random() - 0.5, Math.random() - 0.5);
+    }
 
-		storedItems.clear();
-		equipedCurios.clear();
-		Player owner = getOwnerEntity();
-		if(owner != null && !level().isClientSide) {
-			owner.sendSystemMessage(Component.translatable("quark.misc.totem_darksouls").withStyle(ChatFormatting.BOLD));
-		}
+    private void dropEverythingAndDie() {
+        if (!TotemOfHoldingModule.destroyLostItems)
+            for (ItemStack storedItem : storedItems)
+                spawnAtLocation(storedItem, 0);
 
-		discard();
-	}
+        storedItems.clear();
+        equipedCurios.clear();
+        Player owner = getOwnerEntity();
+        if (owner != null && !level().isClientSide) {
+            owner.sendSystemMessage(Component.translatable("quark.misc.totem_darksouls").withStyle(ChatFormatting.BOLD));
+        }
 
-	public int getDeathTicks() {
-		return deathTicks;
-	}
+        discard();
+    }
 
-	public boolean isDying() {
-		return entityData.get(DYING);
-	}
+    public int getDeathTicks() {
+        return deathTicks;
+    }
 
-	@Override
-	public void readAdditionalSaveData(@NotNull CompoundTag compound) {
-		ListTag list = compound.getList(TAG_ITEMS, 10);
-		ListTag curiosList = compound.getList(TAG_CURIOS, 10);
-		storedItems = new LinkedList<>();
-		equipedCurios = new LinkedList<>();
+    public boolean isDying() {
+        return entityData.get(DYING);
+    }
 
-		for(int i = 0; i < list.size(); i++) {
-			CompoundTag cmp = list.getCompound(i);
-			ItemStack stack = ItemStack.parseOptional(level().registryAccess(), cmp);
-			storedItems.add(stack);
-		}
+    @Override
+    public void readAdditionalSaveData(@NotNull CompoundTag compound) {
+        ListTag list = compound.getList(TAG_ITEMS, 10);
+        ListTag curiosList = compound.getList(TAG_CURIOS, 10);
+        storedItems = new LinkedList<>();
+        equipedCurios = new LinkedList<>();
 
-		for (int i = 0; i < curiosList.size(); i++) {
-			CompoundTag cmp = curiosList.getCompound(i);
-			ItemStack stack = ItemStack.parseOptional(level().registryAccess(), cmp);
-			equipedCurios.add(stack);
-		}
+        for (int i = 0; i < list.size(); i++) {
+            CompoundTag cmp = list.getCompound(i);
+            ItemStack stack = ItemStack.parseOptional(level().registryAccess(), cmp);
+            storedItems.add(stack);
+        }
 
-		boolean dying = compound.getBoolean(TAG_DYING);
-		entityData.set(DYING, dying);
+        for (int i = 0; i < curiosList.size(); i++) {
+            CompoundTag cmp = curiosList.getCompound(i);
+            ItemStack stack = ItemStack.parseOptional(level().registryAccess(), cmp);
+            equipedCurios.add(stack);
+        }
 
-		owner = compound.getString(TAG_OWNER);
-	}
+        boolean dying = compound.getBoolean(TAG_DYING);
+        entityData.set(DYING, dying);
 
-	@Override
-	protected void addAdditionalSaveData(@NotNull CompoundTag compound) {
-		ListTag list = new ListTag();
-		ListTag curiosList = new ListTag();
+        owner = compound.getString(TAG_OWNER);
+    }
 
-		for(ItemStack stack : storedItems) {
-			list.add(stack.save(level().registryAccess()));
-		}
+    @Override
+    protected void addAdditionalSaveData(@NotNull CompoundTag compound) {
+        ListTag list = new ListTag();
+        ListTag curiosList = new ListTag();
 
-		for (ItemStack equipedCurio : equipedCurios) {
+        for (ItemStack stack : storedItems) {
+            list.add(stack.save(level().registryAccess()));
+        }
+
+        for (ItemStack equipedCurio : equipedCurios) {
             if (!equipedCurio.isEmpty()) {
                 curiosList.add(equipedCurio.save(level().registryAccess()));
             }
-		}
+        }
 
-		compound.put(TAG_ITEMS, list);
-		compound.put(TAG_CURIOS, curiosList);
-		compound.putBoolean(TAG_DYING, isDying());
-		if(owner != null)
-			compound.putString(TAG_OWNER, owner);
-	}
+        compound.put(TAG_ITEMS, list);
+        compound.put(TAG_CURIOS, curiosList);
+        compound.putBoolean(TAG_DYING, isDying());
+        if (owner != null)
+            compound.putString(TAG_OWNER, owner);
+    }
 
-	@NotNull
-	@Override
-	public Packet<ClientGamePacketListener> getAddEntityPacket(ServerEntity entity) {
-		return new ClientboundAddEntityPacket(this, entity);
-	}
+    @NotNull
+    @Override
+    public Packet<ClientGamePacketListener> getAddEntityPacket(ServerEntity entity) {
+        return new ClientboundAddEntityPacket(this, entity);
+    }
 }

--- a/src/main/java/org/violetmoon/quark/addons/oddities/module/TotemOfHoldingModule.java
+++ b/src/main/java/org/violetmoon/quark/addons/oddities/module/TotemOfHoldingModule.java
@@ -53,6 +53,10 @@ public class TotemOfHoldingModule extends ZetaModule {
 	@Config(description = "Set this to false to only allow the owner of a totem to collect its items rather than any player")
 	public static boolean allowAnyoneToCollect = true;
 
+	@Config(description = "How many items does the totem of holding drop on each hit? (Set to -1 to drop everything the first hit)")
+	public static int minDropsRecoveredPerHit = 3;
+	public static int maxDropsRecoveredPerHit = 6;
+
 	@LoadEvent
 	public final void register(ZRegister event) {
 		totemType = EntityType.Builder.of(TotemOfHoldingEntity::new, MobCategory.MISC)

--- a/src/main/java/org/violetmoon/quark/addons/oddities/module/TotemOfHoldingModule.java
+++ b/src/main/java/org/violetmoon/quark/addons/oddities/module/TotemOfHoldingModule.java
@@ -53,8 +53,9 @@ public class TotemOfHoldingModule extends ZetaModule {
 	@Config(description = "Set this to false to only allow the owner of a totem to collect its items rather than any player")
 	public static boolean allowAnyoneToCollect = true;
 
-	@Config(description = "How many items does the totem of holding drop on each hit? (Set to -1 to drop everything the first hit)")
+	@Config(description = "Min item drops per hit (Set to -1 to drop everything the first hit)")
 	public static int minDropsRecoveredPerHit = 3;
+	@Config(description = "Max item drops per hit (Set to -1 to drop everything the first hit)")
 	public static int maxDropsRecoveredPerHit = 6;
 
 	@LoadEvent


### PR DESCRIPTION
I was quite frustrated to discover that the totem of holding in Quark Oddities didn't have a configurable way to drop all items with just a single punch, so Im making this contribution.

You can set how many items are dropped when hitting the totem of holding, The default is between 3 and 6 which is what it originally was. If set to -1, the totem of holding drops everything on the first hit.