### PR TITLE
Make glowshrooms more data-driven

### DIFF
--- a/src/main/java/org/violetmoon/quark/content/world/block/GlowShroomBlock.java
+++ b/src/main/java/org/violetmoon/quark/content/world/block/GlowShroomBlock.java
@@ -1,6 +1,7 @@
 package org.violetmoon.quark.content.world.block;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.server.level.ServerLevel;
@@ -13,16 +14,17 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.BonemealableBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
 import org.violetmoon.quark.base.Quark;
-import org.violetmoon.quark.content.world.feature.GlowShroomsFeature;
+import org.violetmoon.quark.content.world.module.GlimmeringWealdModule;
 import org.violetmoon.zeta.block.ZetaBushBlock;
 import org.violetmoon.zeta.module.ZetaModule;
+
+import java.util.Optional;
 
 public class GlowShroomBlock extends ZetaBushBlock implements BonemealableBlock {
 
@@ -74,7 +76,9 @@ public class GlowShroomBlock extends ZetaBushBlock implements BonemealableBlock 
 
 	@Override
 	public void performBonemeal(@NotNull ServerLevel world, @NotNull RandomSource random, @NotNull BlockPos pos, @NotNull BlockState state) {
-		GlowShroomsFeature.placeHugeGlowShroom(world, random, pos);
+		Optional<? extends Holder<ConfiguredFeature<?, ?>>> optional = world.registryAccess().registryOrThrow(Registries.CONFIGURED_FEATURE).getHolder(GlimmeringWealdModule.GLOW_SHROOMS_CONFIGURATION);
+        if (optional.isPresent())
+			optional.get().value().place(world, world.getChunkSource().getGenerator(), random, pos);
 	}
 
 }

--- a/src/main/java/org/violetmoon/quark/content/world/block/GlowShroomBlock.java
+++ b/src/main/java/org/violetmoon/quark/content/world/block/GlowShroomBlock.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import org.violetmoon.quark.base.Quark;
+import org.violetmoon.quark.content.world.feature.GlowShroomsFeature;
 import org.violetmoon.zeta.block.ZetaBushBlock;
 import org.violetmoon.zeta.module.ZetaModule;
 
@@ -73,7 +74,7 @@ public class GlowShroomBlock extends ZetaBushBlock implements BonemealableBlock 
 
 	@Override
 	public void performBonemeal(@NotNull ServerLevel world, @NotNull RandomSource random, @NotNull BlockPos pos, @NotNull BlockState state) {
-		HugeGlowShroomBlock.place(world, random, pos);
+		GlowShroomsFeature.placeHugeGlowShroom(world, random, pos);
 	}
 
 }

--- a/src/main/java/org/violetmoon/quark/content/world/block/HugeGlowShroomBlock.java
+++ b/src/main/java/org/violetmoon/quark/content/world/block/HugeGlowShroomBlock.java
@@ -7,7 +7,6 @@ import org.violetmoon.quark.content.world.module.GlimmeringWealdModule;
 import org.violetmoon.zeta.block.IZetaBlock;
 import org.violetmoon.zeta.module.ZetaModule;
 import org.violetmoon.zeta.registry.CreativeTabManager;
-import org.violetmoon.zeta.util.MiscUtil;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -16,7 +15,6 @@ import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.HugeMushroomBlock;
@@ -63,69 +61,6 @@ public class HugeGlowShroomBlock extends HugeMushroomBlock implements IZetaBlock
 		BlockState below = worldIn.getBlockState(pos.below());
 		if(glowing && rand.nextInt(10) == 0 && (below.isAir() || below.getBlock() == GlimmeringWealdModule.glow_shroom_ring))
 			worldIn.addParticle(ParticleTypes.END_ROD, pos.getX() + rand.nextDouble(), pos.getY(), pos.getZ() + rand.nextDouble(), 0, -0.05 - Math.random() * 0.05, 0);
-	}
-
-	public static boolean place(LevelAccessor worldIn, RandomSource rand, BlockPos pos) {
-		Block block = worldIn.getBlockState(pos.below()).getBlock();
-		if(block != Blocks.DEEPSLATE) {
-			return false;
-		} else {
-			BlockPos placePos = pos;
-
-			BlockState stem = GlimmeringWealdModule.glow_shroom_stem.defaultBlockState();
-			BlockState ring = GlimmeringWealdModule.glow_shroom_ring.defaultBlockState();
-			BlockState cap = GlimmeringWealdModule.glow_shroom_block.defaultBlockState().setValue(HugeGlowShroomBlock.DOWN, false);
-
-			int stemHeight1 = 2;
-			int stemHeight2 = rand.nextInt(4);
-			boolean hasBigCap = rand.nextDouble() < 0.6;
-
-			// Check if it has space
-			int totalHeight = stemHeight1 + stemHeight2 + (hasBigCap ? 2 : 1);
-			int horizCheck = 2;
-
-			for(int i = -horizCheck; i < horizCheck + 1; i++)
-				for(int j = -horizCheck; j < horizCheck + 1; j++)
-					for(int k = 1; k < totalHeight; k++) // start at 1 cuz ground layer doesn't matter
-						if(!worldIn.getBlockState(placePos.offset(i, k, j)).isAir())
-							return false;
-
-			// Stem #1
-			for(int i = 0; i < stemHeight1; i++) {
-				worldIn.setBlock(placePos, stem, 2);
-				placePos = placePos.above();
-			}
-
-			// Offset stem in random direction
-			if(stemHeight2 > 0) {
-				Direction dir = MiscUtil.HORIZONTALS[rand.nextInt(MiscUtil.HORIZONTALS.length)];
-				placePos = placePos.relative(dir);
-			}
-
-			// Stem #2
-			for(int i = 0; i < stemHeight2; i++) {
-				worldIn.setBlock(placePos, stem, 2);
-				placePos = placePos.above();
-			}
-
-			// Place rings on top of stem
-			int ringHeight = Math.min(2, stemHeight2);
-			for(int i = 0; i < ringHeight; i++) {
-				for(Direction ringDir : MiscUtil.HORIZONTALS)
-					worldIn.setBlock(placePos.relative(ringDir).relative(Direction.DOWN, i + 1), ring.setValue(GlowShroomRingBlock.FACING, ringDir), 2);
-			}
-
-			// Cap
-			for(int i = -1; i < 2; i++)
-				for(int j = -1; j < 2; j++)
-					worldIn.setBlock(placePos.offset(i, 0, j), cap, 2);
-
-			// Triangle cap
-			if(hasBigCap)
-				worldIn.setBlock(placePos.above(), cap, 2);
-
-			return true;
-		}
 	}
 
 	@Override

--- a/src/main/java/org/violetmoon/quark/content/world/feature/GlowShroomsFeature.java
+++ b/src/main/java/org/violetmoon/quark/content/world/feature/GlowShroomsFeature.java
@@ -6,7 +6,9 @@ import net.minecraft.core.Direction;
 import net.minecraft.data.worldgen.placement.PlacementUtils;
 import net.minecraft.util.RandomSource;
 import net.minecraft.util.valueproviders.ConstantInt;
+import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.WorldGenLevel;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.blockpredicates.BlockPredicate;
@@ -20,8 +22,10 @@ import net.minecraft.world.level.levelgen.placement.InSquarePlacement;
 import net.minecraft.world.level.levelgen.placement.PlacementModifier;
 import net.minecraft.world.level.levelgen.placement.RandomOffsetPlacement;
 
+import org.violetmoon.quark.content.world.block.GlowShroomRingBlock;
 import org.violetmoon.quark.content.world.block.HugeGlowShroomBlock;
 import org.violetmoon.quark.content.world.module.GlimmeringWealdModule;
+import org.violetmoon.zeta.util.MiscUtil;
 
 import java.util.Arrays;
 import java.util.List;
@@ -64,7 +68,7 @@ public class GlowShroomsFeature extends Feature<NoneFeatureConfiguration> {
 
 					if(worldgenlevel.isStateAtPosition(setPos, s -> s.getBlock() == Blocks.DEEPSLATE) && worldgenlevel.isStateAtPosition(setPos.above(), BlockState::isAir)) {
 						if(rng.nextDouble() < 0.08) {
-							boolean placeSmall = !HugeGlowShroomBlock.place(worldgenlevel, rng, setPos.above());
+							boolean placeSmall = !placeHugeGlowShroom(worldgenlevel, rng, setPos.above());
 
 							if(placeSmall)
 								worldgenlevel.setBlock(setPos.above(), GlimmeringWealdModule.glow_shroom.defaultBlockState(), 2);
@@ -73,6 +77,69 @@ public class GlowShroomsFeature extends Feature<NoneFeatureConfiguration> {
 				}
 
 		return true;
+	}
+
+	public static boolean placeHugeGlowShroom(LevelAccessor worldIn, RandomSource rand, BlockPos pos) {
+		Block block = worldIn.getBlockState(pos.below()).getBlock();
+		if(block != Blocks.DEEPSLATE) {
+			return false;
+		} else {
+			BlockPos placePos = pos;
+
+			BlockState stem = GlimmeringWealdModule.glow_shroom_stem.defaultBlockState();
+			BlockState ring = GlimmeringWealdModule.glow_shroom_ring.defaultBlockState();
+			BlockState cap = GlimmeringWealdModule.glow_shroom_block.defaultBlockState().setValue(HugeGlowShroomBlock.DOWN, false);
+
+			int stemHeight1 = 2;
+			int stemHeight2 = rand.nextInt(4);
+			boolean hasBigCap = rand.nextDouble() < 0.6;
+
+			// Check if it has space
+			int totalHeight = stemHeight1 + stemHeight2 + (hasBigCap ? 2 : 1);
+			int horizCheck = 2;
+
+			for(int i = -horizCheck; i < horizCheck + 1; i++)
+				for(int j = -horizCheck; j < horizCheck + 1; j++)
+					for(int k = 1; k < totalHeight; k++) // start at 1 cuz ground layer doesn't matter
+						if(!worldIn.getBlockState(placePos.offset(i, k, j)).isAir())
+							return false;
+
+			// Stem #1
+			for(int i = 0; i < stemHeight1; i++) {
+				worldIn.setBlock(placePos, stem, 2);
+				placePos = placePos.above();
+			}
+
+			// Offset stem in random direction
+			if(stemHeight2 > 0) {
+				Direction dir = MiscUtil.HORIZONTALS[rand.nextInt(MiscUtil.HORIZONTALS.length)];
+				placePos = placePos.relative(dir);
+			}
+
+			// Stem #2
+			for(int i = 0; i < stemHeight2; i++) {
+				worldIn.setBlock(placePos, stem, 2);
+				placePos = placePos.above();
+			}
+
+			// Place rings on top of stem
+			int ringHeight = Math.min(2, stemHeight2);
+			for(int i = 0; i < ringHeight; i++) {
+				for(Direction ringDir : MiscUtil.HORIZONTALS)
+					worldIn.setBlock(placePos.relative(ringDir).relative(Direction.DOWN, i + 1), ring.setValue(GlowShroomRingBlock.FACING, ringDir), 2);
+			}
+
+			// Cap
+			for(int i = -1; i < 2; i++)
+				for(int j = -1; j < 2; j++)
+					worldIn.setBlock(placePos.offset(i, 0, j), cap, 2);
+
+			// Triangle cap
+			if(hasBigCap)
+				worldIn.setBlock(placePos.above(), cap, 2);
+
+			return true;
+		}
 	}
 
 }

--- a/src/main/java/org/violetmoon/quark/content/world/feature/GlowShroomsFeature.java
+++ b/src/main/java/org/violetmoon/quark/content/world/feature/GlowShroomsFeature.java
@@ -106,7 +106,7 @@ public class GlowShroomsFeature extends Feature<GlowShroomsFeatureConfiguration>
 					BlockPos relativePos = placePos.relative(ringDir).relative(Direction.DOWN, i + 1);
 					BlockState ring = config.ringProvider().getState(rand, relativePos);
 					if(ring.hasProperty(GlowShroomRingBlock.FACING))
-						ring.setValue(GlowShroomRingBlock.FACING, ringDir);
+						ring = ring.setValue(GlowShroomRingBlock.FACING, ringDir);
 					worldIn.setBlock(relativePos, ring, 2);
 				}
 			}

--- a/src/main/java/org/violetmoon/quark/content/world/feature/GlowShroomsFeature.java
+++ b/src/main/java/org/violetmoon/quark/content/world/feature/GlowShroomsFeature.java
@@ -14,9 +14,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.blockpredicates.BlockPredicate;
 import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.levelgen.feature.FeaturePlaceContext;
-import net.minecraft.world.level.levelgen.feature.configurations.HugeMushroomFeatureConfiguration;
 import net.minecraft.world.level.levelgen.placement.*;
-import org.violetmoon.quark.base.Quark;
 import org.violetmoon.quark.content.world.block.GlowShroomRingBlock;
 import org.violetmoon.quark.content.world.module.GlimmeringWealdModule;
 import org.violetmoon.zeta.util.MiscUtil;
@@ -24,11 +22,10 @@ import org.violetmoon.zeta.util.MiscUtil;
 import java.util.Arrays;
 import java.util.List;
 
-public class GlowShroomsFeature extends Feature<HugeMushroomFeatureConfiguration> {
+public class GlowShroomsFeature extends Feature<GlowShroomsFeatureConfiguration> {
 
-	//TODO: this could use some configs
 	public GlowShroomsFeature() {
-		super(HugeMushroomFeatureConfiguration.CODEC);
+		super(GlowShroomsFeatureConfiguration.CODEC);
 	}
 
 	public static List<PlacementModifier> placed() {
@@ -43,11 +40,11 @@ public class GlowShroomsFeature extends Feature<HugeMushroomFeatureConfiguration
 	// /tp 1035 -38 -368
 
 	@Override
-	public boolean place(FeaturePlaceContext<HugeMushroomFeatureConfiguration> context) {
+	public boolean place(FeaturePlaceContext<GlowShroomsFeatureConfiguration> context) {
 		WorldGenLevel worldgenlevel = context.level();
 		BlockPos blockpos = context.origin();
 		RandomSource rng = context.random();
-		HugeMushroomFeatureConfiguration config = context.config();
+		GlowShroomsFeatureConfiguration config = context.config();
 
 		MutableBlockPos setPos = new MutableBlockPos(blockpos.getX(), blockpos.getY(), blockpos.getZ());
 		if(!placeHugeGlowShroom(worldgenlevel, rng, setPos, config))
@@ -56,33 +53,33 @@ public class GlowShroomsFeature extends Feature<HugeMushroomFeatureConfiguration
 		return true;
 	}
 
-	public static boolean placeHugeGlowShroom(LevelAccessor worldIn, RandomSource rand, BlockPos pos, HugeMushroomFeatureConfiguration config) {
+	public static boolean placeHugeGlowShroom(LevelAccessor worldIn, RandomSource rand, BlockPos pos, GlowShroomsFeatureConfiguration config) {
 		Block block = worldIn.getBlockState(pos.below()).getBlock();
 		if(block != Blocks.DEEPSLATE) {
 			return false;
 		} else {
 			BlockPos placePos = pos;
 
-			BlockState ring = GlimmeringWealdModule.glow_shroom_ring.defaultBlockState();
-
-			int stemHeight1 = 2;
-			int stemHeight2 = rand.nextInt(4);
-			int capRadius = config.foliageRadius;
+			int stemHeight1 = config.baseHeight();
+			int stemHeight2 = rand.nextInt(config.heightRand());
+			int capRadius = config.foliageRadius();
 			boolean hasBigCap = rand.nextDouble() < 0.6;
 
 			// Check if it has space
-			int totalHeight = stemHeight1 + stemHeight2 + (hasBigCap ? 2 : 1);
-			int horizCheck = capRadius + 1;
+			int stemHeight = stemHeight1 + stemHeight2;
+			int totalHeight = stemHeight + (hasBigCap ? 2 : 1);
 
-			for(int i = -horizCheck; i < horizCheck + 1; i++)
-				for(int j = -horizCheck; j < horizCheck + 1; j++)
-					for(int k = 1; k < totalHeight; k++) // start at 1 cuz ground layer doesn't matter
+			for(int k = 1; k < totalHeight; k++) { // start at 1 cuz ground layer doesn't matter
+				int horizCheck = k < stemHeight ? 2 : capRadius + 1;
+				for(int i = -horizCheck; i <= horizCheck; i++)
+					for(int j = -horizCheck; j <= horizCheck; j++)
 						if(!worldIn.getBlockState(placePos.offset(i, k, j)).isAir())
 							return false;
+			}
 
 			// Stem #1
 			for(int i = 0; i < stemHeight1; i++) {
-				worldIn.setBlock(placePos, config.stemProvider.getState(rand, placePos), 2);
+				worldIn.setBlock(placePos, config.stemProvider().getState(rand, placePos), 2);
 				placePos = placePos.above();
 			}
 
@@ -94,25 +91,34 @@ public class GlowShroomsFeature extends Feature<HugeMushroomFeatureConfiguration
 
 			// Stem #2
 			for(int i = 0; i < stemHeight2; i++) {
-				worldIn.setBlock(placePos, config.stemProvider.getState(rand, placePos), 2);
+				worldIn.setBlock(placePos, config.stemProvider().getState(rand, placePos), 2);
 				placePos = placePos.above();
 			}
 
 			// Place rings on top of stem
 			int ringHeight = Math.min(2, stemHeight2);
 			for(int i = 0; i < ringHeight; i++) {
-				for(Direction ringDir : MiscUtil.HORIZONTALS)
-					worldIn.setBlock(placePos.relative(ringDir).relative(Direction.DOWN, i + 1), ring.setValue(GlowShroomRingBlock.FACING, ringDir), 2);
+				for(Direction ringDir : MiscUtil.HORIZONTALS) {
+					BlockPos relativePos = placePos.relative(ringDir).relative(Direction.DOWN, i + 1);
+					BlockState ring = config.ringProvider().getState(rand, relativePos);
+					if(ring.hasProperty(GlowShroomRingBlock.FACING))
+						ring.setValue(GlowShroomRingBlock.FACING, ringDir);
+					worldIn.setBlock(relativePos, ring, 2);
+				}
 			}
 
 			// Cap
 			for(int i = -capRadius; i <= capRadius; i++)
-				for(int j = -capRadius; j <= capRadius; j++)
-					worldIn.setBlock(placePos.offset(i, 0, j), config.capProvider.getState(rand, placePos), 2);
+				for(int j = -capRadius; j <= capRadius; j++) {
+					BlockPos relativePos = placePos.offset(i, 0, j);
+					worldIn.setBlock(relativePos, config.capProvider().getState(rand, relativePos), 2);
+				}
 
 			// Triangle cap
-			if(hasBigCap)
-				worldIn.setBlock(placePos.above(), config.capProvider.getState(rand, placePos), 2);
+			if(hasBigCap) {
+				placePos = placePos.above();
+				worldIn.setBlock(placePos, config.capProvider().getState(rand, placePos), 2);
+			}
 
 			return true;
 		}

--- a/src/main/java/org/violetmoon/quark/content/world/feature/GlowShroomsFeature.java
+++ b/src/main/java/org/violetmoon/quark/content/world/feature/GlowShroomsFeature.java
@@ -3,18 +3,20 @@ package org.violetmoon.quark.content.world.feature;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.BlockPos.MutableBlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.data.worldgen.placement.PlacementUtils;
+import net.minecraft.tags.TagKey;
 import net.minecraft.util.RandomSource;
 import net.minecraft.util.valueproviders.ConstantInt;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.WorldGenLevel;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.blockpredicates.BlockPredicate;
 import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.levelgen.feature.FeaturePlaceContext;
 import net.minecraft.world.level.levelgen.placement.*;
+import org.violetmoon.quark.base.Quark;
 import org.violetmoon.quark.content.world.block.GlowShroomRingBlock;
 import org.violetmoon.quark.content.world.module.GlimmeringWealdModule;
 import org.violetmoon.zeta.util.MiscUtil;
@@ -23,6 +25,8 @@ import java.util.Arrays;
 import java.util.List;
 
 public class GlowShroomsFeature extends Feature<GlowShroomsFeatureConfiguration> {
+
+	protected static final TagKey<Block> GLOW_SHROOM_GROW_BLOCK = Quark.asTagKey(Registries.BLOCK, "glow_shroom_grow_block");
 
 	public GlowShroomsFeature() {
 		super(GlowShroomsFeatureConfiguration.CODEC);
@@ -54,8 +58,8 @@ public class GlowShroomsFeature extends Feature<GlowShroomsFeatureConfiguration>
 	}
 
 	public static boolean placeHugeGlowShroom(LevelAccessor worldIn, RandomSource rand, BlockPos pos, GlowShroomsFeatureConfiguration config) {
-		Block block = worldIn.getBlockState(pos.below()).getBlock();
-		if(block != Blocks.DEEPSLATE) {
+		BlockState state = worldIn.getBlockState(pos.below());
+		if(!state.is(GLOW_SHROOM_GROW_BLOCK)) {
 			return false;
 		} else {
 			BlockPos placePos = pos;

--- a/src/main/java/org/violetmoon/quark/content/world/feature/GlowShroomsFeature.java
+++ b/src/main/java/org/violetmoon/quark/content/world/feature/GlowShroomsFeature.java
@@ -14,27 +14,21 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.blockpredicates.BlockPredicate;
 import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.levelgen.feature.FeaturePlaceContext;
-import net.minecraft.world.level.levelgen.feature.configurations.NoneFeatureConfiguration;
-import net.minecraft.world.level.levelgen.placement.BiomeFilter;
-import net.minecraft.world.level.levelgen.placement.CountPlacement;
-import net.minecraft.world.level.levelgen.placement.EnvironmentScanPlacement;
-import net.minecraft.world.level.levelgen.placement.InSquarePlacement;
-import net.minecraft.world.level.levelgen.placement.PlacementModifier;
-import net.minecraft.world.level.levelgen.placement.RandomOffsetPlacement;
-
+import net.minecraft.world.level.levelgen.feature.configurations.HugeMushroomFeatureConfiguration;
+import net.minecraft.world.level.levelgen.placement.*;
+import org.violetmoon.quark.base.Quark;
 import org.violetmoon.quark.content.world.block.GlowShroomRingBlock;
-import org.violetmoon.quark.content.world.block.HugeGlowShroomBlock;
 import org.violetmoon.quark.content.world.module.GlimmeringWealdModule;
 import org.violetmoon.zeta.util.MiscUtil;
 
 import java.util.Arrays;
 import java.util.List;
 
-public class GlowShroomsFeature extends Feature<NoneFeatureConfiguration> {
+public class GlowShroomsFeature extends Feature<HugeMushroomFeatureConfiguration> {
 
 	//TODO: this could use some configs
 	public GlowShroomsFeature() {
-		super(NoneFeatureConfiguration.CODEC);
+		super(HugeMushroomFeatureConfiguration.CODEC);
 	}
 
 	public static List<PlacementModifier> placed() {
@@ -49,54 +43,36 @@ public class GlowShroomsFeature extends Feature<NoneFeatureConfiguration> {
 	// /tp 1035 -38 -368
 
 	@Override
-	public boolean place(FeaturePlaceContext<NoneFeatureConfiguration> config) {
-		WorldGenLevel worldgenlevel = config.level();
-		BlockPos blockpos = config.origin();
-		RandomSource rng = config.random();
+	public boolean place(FeaturePlaceContext<HugeMushroomFeatureConfiguration> context) {
+		WorldGenLevel worldgenlevel = context.level();
+		BlockPos blockpos = context.origin();
+		RandomSource rng = context.random();
+		HugeMushroomFeatureConfiguration config = context.config();
 
 		MutableBlockPos setPos = new MutableBlockPos(blockpos.getX(), blockpos.getY(), blockpos.getZ());
-		for(int i = -6; i < 7; i++)
-			for(int j = -6; j < 7; j++)
-				for(int k = -2; k < 3; k++) {
-					setPos.set(blockpos.getX() + i, blockpos.getY() + k, blockpos.getZ() + j);
-					double dist = blockpos.distSqr(setPos);
-					if(dist > 10) {
-						double chance = 1F - ((dist - 10) / 10);
-						if(chance < 0 || rng.nextDouble() < chance)
-							continue;
-					}
-
-					if(worldgenlevel.isStateAtPosition(setPos, s -> s.getBlock() == Blocks.DEEPSLATE) && worldgenlevel.isStateAtPosition(setPos.above(), BlockState::isAir)) {
-						if(rng.nextDouble() < 0.08) {
-							boolean placeSmall = !placeHugeGlowShroom(worldgenlevel, rng, setPos.above());
-
-							if(placeSmall)
-								worldgenlevel.setBlock(setPos.above(), GlimmeringWealdModule.glow_shroom.defaultBlockState(), 2);
-						}
-					}
-				}
+		if(!placeHugeGlowShroom(worldgenlevel, rng, setPos, config))
+			worldgenlevel.setBlock(setPos, GlimmeringWealdModule.glow_shroom.defaultBlockState(), 2);
 
 		return true;
 	}
 
-	public static boolean placeHugeGlowShroom(LevelAccessor worldIn, RandomSource rand, BlockPos pos) {
+	public static boolean placeHugeGlowShroom(LevelAccessor worldIn, RandomSource rand, BlockPos pos, HugeMushroomFeatureConfiguration config) {
 		Block block = worldIn.getBlockState(pos.below()).getBlock();
 		if(block != Blocks.DEEPSLATE) {
 			return false;
 		} else {
 			BlockPos placePos = pos;
 
-			BlockState stem = GlimmeringWealdModule.glow_shroom_stem.defaultBlockState();
 			BlockState ring = GlimmeringWealdModule.glow_shroom_ring.defaultBlockState();
-			BlockState cap = GlimmeringWealdModule.glow_shroom_block.defaultBlockState().setValue(HugeGlowShroomBlock.DOWN, false);
 
 			int stemHeight1 = 2;
 			int stemHeight2 = rand.nextInt(4);
+			int capRadius = config.foliageRadius;
 			boolean hasBigCap = rand.nextDouble() < 0.6;
 
 			// Check if it has space
 			int totalHeight = stemHeight1 + stemHeight2 + (hasBigCap ? 2 : 1);
-			int horizCheck = 2;
+			int horizCheck = capRadius + 1;
 
 			for(int i = -horizCheck; i < horizCheck + 1; i++)
 				for(int j = -horizCheck; j < horizCheck + 1; j++)
@@ -106,7 +82,7 @@ public class GlowShroomsFeature extends Feature<NoneFeatureConfiguration> {
 
 			// Stem #1
 			for(int i = 0; i < stemHeight1; i++) {
-				worldIn.setBlock(placePos, stem, 2);
+				worldIn.setBlock(placePos, config.stemProvider.getState(rand, placePos), 2);
 				placePos = placePos.above();
 			}
 
@@ -118,7 +94,7 @@ public class GlowShroomsFeature extends Feature<NoneFeatureConfiguration> {
 
 			// Stem #2
 			for(int i = 0; i < stemHeight2; i++) {
-				worldIn.setBlock(placePos, stem, 2);
+				worldIn.setBlock(placePos, config.stemProvider.getState(rand, placePos), 2);
 				placePos = placePos.above();
 			}
 
@@ -130,13 +106,13 @@ public class GlowShroomsFeature extends Feature<NoneFeatureConfiguration> {
 			}
 
 			// Cap
-			for(int i = -1; i < 2; i++)
-				for(int j = -1; j < 2; j++)
-					worldIn.setBlock(placePos.offset(i, 0, j), cap, 2);
+			for(int i = -capRadius; i <= capRadius; i++)
+				for(int j = -capRadius; j <= capRadius; j++)
+					worldIn.setBlock(placePos.offset(i, 0, j), config.capProvider.getState(rand, placePos), 2);
 
 			// Triangle cap
 			if(hasBigCap)
-				worldIn.setBlock(placePos.above(), cap, 2);
+				worldIn.setBlock(placePos.above(), config.capProvider.getState(rand, placePos), 2);
 
 			return true;
 		}

--- a/src/main/java/org/violetmoon/quark/content/world/feature/GlowShroomsFeatureConfiguration.java
+++ b/src/main/java/org/violetmoon/quark/content/world/feature/GlowShroomsFeatureConfiguration.java
@@ -1,0 +1,12 @@
+package org.violetmoon.quark.content.world.feature;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.world.level.levelgen.feature.configurations.FeatureConfiguration;
+import net.minecraft.world.level.levelgen.feature.stateproviders.BlockStateProvider;
+
+public record GlowShroomsFeatureConfiguration(BlockStateProvider capProvider, BlockStateProvider stemProvider,
+                                              BlockStateProvider ringProvider, int foliageRadius, int baseHeight,
+                                              int heightRand) implements FeatureConfiguration {
+    public static final Codec<GlowShroomsFeatureConfiguration> CODEC = RecordCodecBuilder.create(instance -> instance.group(BlockStateProvider.CODEC.fieldOf("cap_provider").forGetter(s -> s.capProvider), BlockStateProvider.CODEC.fieldOf("stem_provider").forGetter(s -> s.stemProvider), BlockStateProvider.CODEC.fieldOf("ring_provider").forGetter(s -> s.ringProvider), Codec.INT.fieldOf("foliage_radius").forGetter(s -> s.foliageRadius), Codec.INT.fieldOf("base_height").forGetter(s -> s.baseHeight), Codec.INT.fieldOf("height_rand").forGetter(s -> s.heightRand)).apply(instance, GlowShroomsFeatureConfiguration::new));
+}

--- a/src/main/java/org/violetmoon/quark/content/world/module/GlimmeringWealdModule.java
+++ b/src/main/java/org/violetmoon/quark/content/world/module/GlimmeringWealdModule.java
@@ -14,6 +14,7 @@ import net.minecraft.world.level.biome.Climate;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.FlowerPotBlock;
+import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
 import org.violetmoon.quark.base.Quark;
 import org.violetmoon.quark.base.util.CompostManager;
@@ -38,6 +39,8 @@ public class GlimmeringWealdModule extends ZetaModule {
 
     public static final ResourceLocation BIOME_NAME = Quark.asResource("glimmering_weald");
     public static final ResourceKey<Biome> BIOME_KEY = Quark.asResourceKey(Registries.BIOME, "glimmering_weald");
+
+    public static ResourceKey<ConfiguredFeature<?, ?>> GLOW_SHROOMS_CONFIGURATION = Quark.asResourceKey(Registries.CONFIGURED_FEATURE, "glow_shrooms");
 
 	public static ResourceKey<PlacedFeature> GLOW_SHROOMS_FEATURE = Quark.asResourceKey(Registries.PLACED_FEATURE, "glow_shrooms");
 	public static ResourceKey<PlacedFeature> GLOW_SHROOMS_EXTRAS_FEATURE = Quark.asResourceKey(Registries.PLACED_FEATURE, "glow_shrooms_extras");
@@ -121,8 +124,6 @@ public class GlimmeringWealdModule extends ZetaModule {
 
         Quark.ZETA.advancementModifierRegistry.addModifier(new AdventuringTimeModifier(this, ImmutableSet.of(BIOME_KEY)));
     }
-
-
 
     @LoadEvent
     public void setup(ZCommonSetup e) {

--- a/src/main/resources/data/quark/tags/block/glow_shroom_grow_block.json
+++ b/src/main/resources/data/quark/tags/block/glow_shroom_grow_block.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:deepslate"
+  ]
+}

--- a/src/main/resources/data/quark/worldgen/configured_feature/glow_shrooms.json
+++ b/src/main/resources/data/quark/worldgen/configured_feature/glow_shrooms.json
@@ -29,6 +29,14 @@
           "west": "true"
         }
       }
+    },
+    "base_height": 2,
+    "height_rand": 4,
+    "ring_provider": {
+      "type": "minecraft:simple_state_provider",
+      "state": {
+        "Name": "quark:glow_shroom_ring"
+      }
     }
   }
 }

--- a/src/main/resources/data/quark/worldgen/configured_feature/glow_shrooms.json
+++ b/src/main/resources/data/quark/worldgen/configured_feature/glow_shrooms.json
@@ -1,0 +1,34 @@
+{
+  "type": "quark:glow_shrooms",
+  "config": {
+    "cap_provider": {
+      "type": "minecraft:simple_state_provider",
+      "state": {
+        "Name": "quark:glow_shroom_block",
+        "Properties": {
+          "down": "false",
+          "east": "true",
+          "north": "true",
+          "south": "true",
+          "up": "true",
+          "west": "true"
+        }
+      }
+    },
+    "foliage_radius": 1,
+    "stem_provider": {
+      "type": "minecraft:simple_state_provider",
+      "state": {
+        "Name": "quark:glow_shroom_stem",
+        "Properties": {
+          "down": "false",
+          "east": "true",
+          "north": "true",
+          "south": "true",
+          "up": "false",
+          "west": "true"
+        }
+      }
+    }
+  }
+}

--- a/src/main/resources/data/quark/worldgen/placed_feature/glow_shrooms.json
+++ b/src/main/resources/data/quark/worldgen/placed_feature/glow_shrooms.json
@@ -1,8 +1,5 @@
 {
-  "feature":   {
-    "config": {},
-    "type": "quark:glow_shrooms"
-  },
+  "feature": "quark:glow_shrooms",
   "placement": [
     {
       "count": 125,

--- a/src/main/resources/data/quark/worldgen/placed_feature/glow_shrooms.json
+++ b/src/main/resources/data/quark/worldgen/placed_feature/glow_shrooms.json
@@ -6,6 +6,10 @@
       "type": "minecraft:count"
     },
     {
+      "count": 5,
+      "type": "minecraft:count"
+    },
+    {
       "type": "minecraft:in_square"
     },
     {


### PR DESCRIPTION
Currently, glowshrooms do not use a configured feature, which makes it harder for datapack makers and other mod makers to edit and customize the feature. This PR adds the `GlowShroomsFeatureConfiguration`, which allows for the following to be edited via datapack:

- `cap_provider`: specifies what `BlockState` to use for the cap of the glowshroom
- `stem_provider`: same, but for the stem
- `ring_provider`: same, but for the ring
- `foliage_radius`: an `int` determining the Chebyshev radius of the foliage (default is `1`)
- `base_height`: specifies the height of the stem *before* the offset (default is `2`)
- `height_rand`: specifies the maximum height possible for the offset stem (default is `4`)

As a part of this rewrite, I refactored the `HugeGlowShroomBlock.place` method into the `GlowShroomsFeature` class, as it now does not necessarily have to do with any of the glowshroom blocks; this can be reverted if wished. Additionally, I had to remove the nested loops in the `place` method, 

https://github.com/VazkiiMods/Quark/blob/329212eee86b6ee15a03d143545f0e4f66896224/src/main/java/org/violetmoon/quark/content/world/feature/GlowShroomsFeature.java#L54-L56

to ensure that the bonemealing method still worked, and so I increased the `count` of the placed feature by 5 times to account for this.

Finally, I changed the base block for the glowshroom to grow to be tag-based, so it is now controlled by the block tag `quark:glow_shroom_grow_block` (cf. `minecraft:mushroom_grow_block`).

Let me know if there is anything you would like me to change for this PR to be accepted.

<img width="1708" height="960" alt="2026-07-19_18 37 07" src="https://github.com/user-attachments/assets/d3b5540d-c525-4603-b3db-f96aa33d0731" />

_A new and improved huge glowshroom, with azalea wood as its stem, dead coral fans for the ring and a radius-3 bedrock cap._